### PR TITLE
HMS-2151 fix: remember settings on step-back to token page

### DIFF
--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -121,6 +121,12 @@ const WizardPage = () => {
   };
 
   const onVerify = (value: VerifyState, data?: Domain) => {
+    if (appContext.wizard.getRegisteredStatus() === 'completed') {
+      // verify was previously completed (e.g. user stepped the wizard
+      // back to the token page.  Do not overwrite the domain value,
+      // so that we do not discard any user-specified settings.
+      return;
+    }
     appContext.wizard.setRegisteredStatus(value);
     if (value === 'completed') {
       data && appContext.wizard.setDomain(data);


### PR DESCRIPTION
If the user steps back to the token page, settings they provided in the later pages of wizard are forgotten.

Avoid this by updating `onVerify` to return early if it detects that the registered state is already `'completed'`.  This avoid overwriting the domain in the wizard state with the "pristine" domain data from the `VerifyRegistry` component.