### PR TITLE
HMS-2151 fix: make it possible to accept defaults

### DIFF
--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -122,21 +122,29 @@ const WizardPage = () => {
 
   const onVerify = (value: VerifyState, data?: Domain) => {
     appContext.wizard.setRegisteredStatus(value);
-    if (value === 'completed') {
-      data && appContext.wizard.setDomain(data);
+    if (value === 'completed' && data !== undefined) {
+      appContext.wizard.setDomain(data);
       setCanJumpPage3(true);
+      // Check whether initial values for user-configurable fields
+      // are valid.  They should be, which will enable the user to
+      // accept the defaults as-is.
+      onUserInputChange(data);
     } else {
       setCanJumpPage3(false);
     }
   };
 
+  // User changed an input that could affect data validity.
+  // Check validity and set "Next" button state accordingly.
+  const onUserInputChange = (domain: Domain): void => {
+    const good = domain.title ? domain.title.length > 0 : false;
+    setCanJumpPage4(good);
+  };
+
   const onChangeTitle = (value: string) => {
-    appContext.wizard.setDomain({ ...domain, title: value });
-    if (value.length > 0) {
-      setCanJumpPage4(true);
-    } else {
-      setCanJumpPage4(false);
-    }
+    const newDomain: Domain = { ...domain, title: value };
+    appContext.wizard.setDomain(newDomain);
+    onUserInputChange(newDomain);
   };
 
   const onChangeDescription = (value: string) => {


### PR DESCRIPTION
The default "title" field comes from the domain record (i.e. whatever ipa-hcc defaults it to).  But the wizard does not enable "Next" on the Service Details page until `onChangeTitle` fires.  In other words, the user *must* change the value before they can proceed.

It should be possible to accept the default.  Extract "data is OK to proceed" behaviour to a new function `onUserInputChange`.  Call this function from `onChangeTitle`, and *also* from `onVerify` when the domain data is first received.

As a result, the Next button on the Service Details page should be enabled immediately, allowing the user to accept the defaults.