### PR TITLE
fix(HMS-3414): Create directories in Containerfile

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -26,6 +26,7 @@ RUN ./gen.app.info.sh
 FROM quay.io/cloudservices/caddy-ubi:11145b1
 WORKDIR /opt/app-root/src
 
+RUN mkdir -p /opt/app-root/src/dist/stable /opt/app-root/src/dist/preview
 COPY build/package/Caddyfile /opt/app-root/src/Caddyfile
 COPY --from=builder /opt/app-root/src/dist /opt/app-root/src/dist/
 COPY --from=builder /opt/app-root/src/app.info.json /opt/app-root/src/dist/


### PR DESCRIPTION
Commit c854f2f52dc8c4c2455d46bf1416170d69db4b8a broke build process:

```
ERROR: failed to solve: failed to compute cache key: failed to calculate
checksum of ref ji869wphngyfym4bml6014fnn::rdlrmumtn45cgenzunvxem3ds:
"/dist": not found
```