### PR TITLE
Infra: Also log into registry.redhat.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,8 @@ yarn-error.log*
 coverage
 
 .env
-secrets
-bin
-.venv
+/secrets
+/bin
+/config/bonfire.yaml
+/.venv
 


### PR DESCRIPTION
The `ephemeral-build` step was only logging into quay.io. It's now also logging into registry.redhat.io. Login is only performed when the container engine does not have a valid session for the registry and `login --get-login` does not return a login.

Also cleanup use of virtual env / `bonfire` CLI. Make targets now explicitly depend on `bonfire` command and no longer source the virtual env.