### PR TITLE
HMS-3595: add UUID column to domain list

### DIFF
--- a/src/Components/DomainList/DomainList.tsx
+++ b/src/Components/DomainList/DomainList.tsx
@@ -218,6 +218,7 @@ export const DomainList = () => {
         <Thead>
           <Tr ouiaId="TrDomainListHeader">
             <Th sort={getSortParams(0)}>Name</Th>
+            <Th>UUID</Th>
             <Th>Type</Th>
             <Th sort={getSortParams(3)}>Domain auto-join on launch</Th>
             <Th></Th>
@@ -246,6 +247,7 @@ export const DomainList = () => {
                       {domain.title}
                     </Button>
                   </Td>
+                  <Td>{domain.domain_id}</Td>
                   <Td>
                     <DomainListFieldType domain_type={domain.domain_type} />
                   </Td>

--- a/src/Routes/WizardPage/Components/PageReview/PageReview.tsx
+++ b/src/Routes/WizardPage/Components/PageReview/PageReview.tsx
@@ -29,7 +29,7 @@ const PageReviewIpaServersHead = () => {
     <Thead>
       <Tr ouiaId="TrPageReviewIpaServers">
         <Th>Name</Th>
-        <Th>UUID</Th>
+        <Th>Subscription Manager ID</Th>
       </Tr>
     </Thead>
   );

--- a/src/Routes/WizardPage/Components/PageReview/PageReview.tsx
+++ b/src/Routes/WizardPage/Components/PageReview/PageReview.tsx
@@ -12,7 +12,16 @@
  */
 import React from 'react';
 
-import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm, Title } from '@patternfly/react-core';
+import {
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListTermHelpText,
+  DescriptionListTermHelpTextButton,
+  Popover,
+  Title,
+} from '@patternfly/react-core';
 
 import './PageReview.scss';
 import { Domain, DomainIpaServer } from '../../../../Api/api';
@@ -137,6 +146,14 @@ const PageReviewIpa = (props: PageReviewProps & { className?: string }) => {
         <DescriptionListGroup>
           <DescriptionListTerm>Domain auto-join on launch</DescriptionListTerm>
           <DescriptionListDescription disabled>{auto_enrollment_description}</DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTermHelpText>
+            <Popover headerContent={<div>UUID</div>} bodyContent={<div>Unique identifier for this registration</div>}>
+              <DescriptionListTermHelpTextButton>UUID</DescriptionListTermHelpTextButton>
+            </Popover>
+          </DescriptionListTermHelpText>
+          <DescriptionListDescription disabled>{props.domain.domain_id}</DescriptionListDescription>
         </DescriptionListGroup>
       </DescriptionList>
     </>


### PR DESCRIPTION
Distinguish domains with same name by adding a UUID column to the domain list.  This change assists test automation, in addition to possibly helping confused users (although we do not think this scenario will be common in real world use).

Fixes: https://issues.redhat.com/browse/HMS-3595

Screenshot of result:

![image](https://github.com/podengo-project/idmsvc-frontend/assets/2331938/e4dfbdc4-2497-4132-bda8-b38ff6535ed0)
