### PR TITLE
fix: frontend container build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ secrets
 
 # Ignore common directories
 .git
-dist
 bin
 node_modules
 .venv


### PR DESCRIPTION
'dist/' ignored at .dockerignore file was
evoking the directory not being copied.