### PR TITLE
feat(HMS-3914): harden Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+.podman
+.docker
+.kube
+
 # Ignore /secrets directory content
 secrets
 
@@ -10,4 +14,5 @@ config/bonfire.yaml
 .npm
 .cache
 .devcontainer
+*.log
 


### PR DESCRIPTION
Add default known directories to be ignored on `.dockerignore` that could have sensible information.

`.docker`, `.podman` and `.kube`.

`*.log`