### PR TITLE
fix(HMS-3784): fix registered domains table refresh

### DIFF
--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -77,7 +77,7 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({ children
    * @param domain The domain to be updated into the context.
    */
   const _updateDomain = (domain: Domain) => {
-    const newDomains: Domain[] = {} as Domain[];
+    const newDomains: Domain[] = [];
     for (const idx in domains) {
       if (domains[idx].domain_id === domain.domain_id) {
         newDomains[idx] = domain;
@@ -94,7 +94,7 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({ children
    * @param id the domain identifier.
    */
   const _deleteDomain = (id: string) => {
-    const newDomains: Domain[] = {} as Domain[];
+    const newDomains: Domain[] = [];
     for (const idx in domains) {
       if (domains[idx].domain_id !== id) {
         newDomains[idx] = domains[idx];

--- a/src/Components/DomainList/DomainList.tsx
+++ b/src/Components/DomainList/DomainList.tsx
@@ -1,6 +1,6 @@
 import { ActionsColumn, IAction, TableComposable, Tbody, Td, Th, ThProps, Thead, Tr } from '@patternfly/react-table';
 import './DomainList.scss';
-import { Fragment, useContext, useState } from 'react';
+import { Fragment, useContext } from 'react';
 import React from 'react';
 
 import { Domain, DomainType, ResourcesApiFactory } from '../../Api/api';
@@ -106,7 +106,7 @@ export const DomainList = () => {
   // Sort direction of the currently sorted column
   const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc'>('asc');
 
-  const [domains, setDomains] = useState<Domain[]>(context?.domains || ([] as Domain[]));
+  const domains = context?.domains || ([] as Domain[]);
   const enabledText = 'Enabled';
   const disabledText = 'Disabled';
 
@@ -123,24 +123,9 @@ export const DomainList = () => {
     columnIndex,
   });
 
-  // given a domain object, replace it in the `domains` state
-  // (matching by uuid).
-  const replaceDomain = (newDomain: Domain): void => {
-    const newDomains = domains.map((domain) => {
-      return domain.domain_id === newDomain.domain_id ? newDomain : domain;
-    });
-    setDomains(newDomains);
-  };
-
   // remove domain(s) matching the given uuid from the `domains` state
   const removeDomain = (uuid: string): void => {
-    const newDomains: Domain[] = [];
-    for (const domain of domains) {
-      if (domain.domain_id !== uuid) {
-        newDomains.push(domain);
-      }
-    }
-    setDomains(newDomains);
+    context?.deleteDomain(uuid);
   };
 
   const onEnableDisable = (domain: Domain) => {
@@ -152,7 +137,7 @@ export const DomainList = () => {
         })
         .then((response) => {
           if (response.status == 200) {
-            replaceDomain(response.data);
+            context?.updateDomain(response.data);
           } else {
             // TODO show-up notification with error message
           }

--- a/src/Routes/DefaultPage/DefaultPage.tsx
+++ b/src/Routes/DefaultPage/DefaultPage.tsx
@@ -140,6 +140,7 @@ const ListContent = () => {
             .readDomain(item.domain_id)
             .then((res_domain) => {
               local_domains[count++] = res_domain.data;
+              // This is executed when the last item was read
               if (res.data.data.length == local_domains.length) {
                 appContext?.setDomains(local_domains);
                 const newOffset = Math.floor((offset + perPage - 1) / perPage) * perPage;


### PR DESCRIPTION
When a new domain was registered, the table was not being refreshed properly, requiring a manual refresh.

This change fix some situation with the application context that was evoking this behavior.