### PR TITLE
fix(HMS-4020): remove or improve help tooltips on details page

### DIFF
--- a/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
+++ b/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
@@ -142,7 +142,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           <DescriptionListTerm>
             Identity domain type
             <Icon className="pf-u-ml-xs">
-              <Tooltip content={'Identity domain type'}>
+              <Tooltip content={'Only Red Hat Identity Management (IdM) is currently supported.'}>
                 <OutlinedQuestionCircleIcon />
               </Tooltip>
             </Icon>
@@ -150,25 +150,11 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           <DescriptionListDescription>Red Hat IdM</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>
-            Kerberos realm
-            <Icon className="pf-u-ml-xs">
-              <Tooltip content={'Kerberos realm'}>
-                <OutlinedQuestionCircleIcon />
-              </Tooltip>
-            </Icon>
-          </DescriptionListTerm>
+          <DescriptionListTerm>Kerberos realm</DescriptionListTerm>
           <DescriptionListDescription>{domain?.['rhel-idm']?.realm_name}</DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>
-            Display name
-            <Icon className="pf-u-ml-xs">
-              <Tooltip content={'Display name'}>
-                <OutlinedQuestionCircleIcon />
-              </Tooltip>
-            </Icon>
-          </DescriptionListTerm>
+          <DescriptionListTerm>Display name</DescriptionListTerm>
           <DescriptionListDescription>
             {title}{' '}
             <Button
@@ -188,14 +174,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm className="pf-u-align-text-top">
-            <Text>
-              Description
-              <Icon className="pf-u-ml-xs">
-                <Tooltip content={'Description'}>
-                  <OutlinedQuestionCircleIcon />
-                </Tooltip>
-              </Icon>
-            </Text>
+            <Text>Description</Text>
           </DescriptionListTerm>
           <DescriptionListDescription className="pf-u-text-wrap">
             <span style={{ whiteSpace: 'pre-line' }}>{description} </span>
@@ -215,14 +194,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
-          <DescriptionListTerm>
-            Red Hat IdM servers
-            <Icon className="pf-u-ml-xs">
-              <Tooltip content={'Red Hat IdM servers'}>
-                <OutlinedQuestionCircleIcon />
-              </Tooltip>
-            </Icon>
-          </DescriptionListTerm>
+          <DescriptionListTerm>Red Hat IdM servers</DescriptionListTerm>
           <DescriptionListDescription>
             <Button
               isInline
@@ -241,7 +213,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           <DescriptionListTerm>
             UUID
             <Icon className="pf-u-ml-xs">
-              <Tooltip content={'UUID'}>
+              <Tooltip content={'Unique ID of this domain registration'}>
                 <OutlinedQuestionCircleIcon />
               </Tooltip>
             </Icon>
@@ -252,7 +224,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           <DescriptionListTerm>
             Domain auto-join on launch
             <Icon className="pf-u-ml-xs">
-              <Tooltip content={'Domain auto-join on launch'}>
+              <Tooltip content={'This option allows hosts to join this identity domain using domain auto-join on launch'}>
                 <OutlinedQuestionCircleIcon />
               </Tooltip>
             </Icon>

--- a/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
+++ b/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
@@ -18,7 +18,6 @@ import { useState } from 'react';
 import { Domain, ResourcesApiFactory } from '../../../../Api';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
-import DownloadIcon from '@patternfly/react-icons/dist/esm/icons/download-icon';
 
 interface DetailGeneralProps {
   domain?: Domain;
@@ -238,34 +237,6 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
               onChange={handleAutoJoin}
               ouiaId="ButtonDetailGeneralAutoenroll"
             />
-          </DescriptionListDescription>
-        </DescriptionListGroup>
-        <DescriptionListGroup>
-          <DescriptionListTerm>
-            Certificate Authority
-            <Icon className="pf-u-ml-xs">
-              <Tooltip content={'Certificate Authority'}>
-                <OutlinedQuestionCircleIcon />
-              </Tooltip>
-            </Icon>
-          </DescriptionListTerm>
-          <DescriptionListDescription>
-            <Button
-              isInline
-              variant="link"
-              onClick={() => {
-                // TODO Add changes when the API endpoint is implemented
-                console.warn('not implemented');
-                new Error('not implemented');
-                return;
-              }}
-              ouiaId="LinkDetailGeneralCertificate"
-            >
-              <Icon>
-                <DownloadIcon />
-              </Icon>{' '}
-              Download certificate
-            </Button>
           </DescriptionListDescription>
         </DescriptionListGroup>
       </DescriptionList>


### PR DESCRIPTION
**fix(HMS-4020): remove or improve help tooltips on details page**

Help tooltips were remove or improved so that there is no
tooltip with the same text as label.


**fix(HMS-4022): remove Certificate authority field from details page**

As it currently doesn't work and it is better to not have it than have
it broken.

Should be brought back in https://issues.redhat.com/browse/HMS-3002

Note: together as HMS-4022 is sort of part of HMS-4020 and separately they could conflict.