### PR TITLE
fix(HMS-4023): paging and reduce number of API requests

### DIFF
--- a/src/Components/DomainList/DomainList.tsx
+++ b/src/Components/DomainList/DomainList.tsx
@@ -21,10 +21,6 @@ export interface DomainListProps {
   domains: Domain[];
 }
 
-export interface DomainProps {
-  domain: Domain;
-}
-
 /**
  * Since OnSort specifies sorted columns by index, we need sortable values
  * for our object by column index.
@@ -97,7 +93,7 @@ export const DomainList = () => {
   const base_url = '/api/idmsvc/v1';
   const resources_api = ResourcesApiFactory(undefined, base_url, undefined);
 
-  const context = useContext<AppContextType | undefined>(AppContext);
+  const context = useContext<AppContextType>(AppContext);
   const navigate = useNavigate();
 
   // Index of the currently sorted column
@@ -108,7 +104,7 @@ export const DomainList = () => {
   // Sort direction of the currently sorted column
   const [activeSortDirection, setActiveSortDirection] = React.useState<'asc' | 'desc'>('asc');
 
-  const domains = context?.domains || ([] as Domain[]);
+  const domains = context.listDomains;
 
   const [isOpenAutoJoinChangeConfirm, setIsOpenAutoJoinChangeConfirm] = useState(false);
   const [isOpenConfirmDelete, setIsOpenConfirmDelete] = useState<boolean>(false);
@@ -132,7 +128,7 @@ export const DomainList = () => {
 
   // remove domain(s) matching the given uuid from the `domains` state
   const removeDomain = (uuid: string): void => {
-    context?.deleteDomain(uuid);
+    context.deleteDomain(uuid);
   };
 
   const showAutoJoinChangeConfirmDialog = (domain: Domain) => {
@@ -157,7 +153,7 @@ export const DomainList = () => {
         })
         .then((response) => {
           if (response.status == 200) {
-            context?.updateDomain(response.data);
+            context.updateDomain(response.data);
           } else {
             // TODO show-up notification with error message
           }
@@ -222,8 +218,8 @@ export const DomainList = () => {
 
   const onShowDetails = (domain: Domain | undefined) => {
     if (domain !== undefined) {
-      context?.setEditing(domain);
-      navigate('/details/' + domain?.domain_id);
+      context.setEditing(domain);
+      navigate('/details/' + domain.domain_id);
     }
   };
 

--- a/src/Routes/DetailPage/DetailPage.tsx
+++ b/src/Routes/DetailPage/DetailPage.tsx
@@ -39,34 +39,35 @@ const DetailPage = () => {
   // Params
   const { domain_id } = useParams();
 
+  if (domain_id === undefined) {
+    navigate('/domains', { replace: true });
+    return <></>;
+  }
+
   // States
-  const [domain, setDomain] = useState<Domain | undefined>(appContext?.getDomain(domain_id || ''));
+  const [domain, setDomain] = useState<Domain | undefined>(appContext?.getDomain(domain_id) || undefined);
   const [isOpenConfirmDelete, setIsOpenConfirmDelete] = useState<boolean>(false);
 
   console.log('INFO:DetailPage render:domain_id=' + domain_id);
 
-  // TODO encapsulate in a custom hook to reuse
-  // Load Domain resource
+  // Load Domain to display
   useEffect(() => {
-    if (domain_id !== undefined && domain === undefined) {
+    if (domain_id) {
       resources_api
         .readDomain(domain_id)
         .then((res) => {
           if (res.status === 200) {
-            console.info('res.data=' + res.data);
-            setDomain(res.data as Domain);
+            appContext?.updateDomain(res.data);
+            setDomain(res.data);
           }
         })
         .catch((reason) => {
-          // TODO Send error notification to chrome
           console.log(reason);
+          console.error('Failed to load domain');
+          navigate('/domains', { replace: true });
         });
     }
-
-    return () => {
-      // Finalizer
-    };
-  }, []);
+  }, [domain_id]);
 
   // Kebab menu
   const [isKebabOpen, setIsKebabOpen] = useState<boolean>(false);

--- a/src/Routes/DetailPage/DetailPage.tsx
+++ b/src/Routes/DetailPage/DetailPage.tsx
@@ -19,7 +19,7 @@ import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-com
 
 import './DetailPage.scss';
 import { Domain, ResourcesApiFactory } from '../../Api/api';
-import { AppContext, AppContextType } from '../../AppContext';
+import { AppContext } from '../../AppContext';
 import { DetailGeneral } from './Components/DetailGeneral/DetailGeneral';
 import { DetailServers } from './Components/DetailServers/DetailServers';
 import ConfirmDeleteDomain from '../../Components/ConfirmDeleteDomain/ConfirmDeleteDomain';
@@ -31,7 +31,7 @@ import ConfirmDeleteDomain from '../../Components/ConfirmDeleteDomain/ConfirmDel
  * @see https://reactrouter.com/en/main/hooks/use-params
  */
 const DetailPage = () => {
-  const appContext = useContext<AppContextType | undefined>(AppContext);
+  const appContext = useContext(AppContext);
   const base_url = '/api/idmsvc/v1';
   const resources_api = ResourcesApiFactory(undefined, base_url, undefined);
   const navigate = useNavigate();

--- a/src/Routes/WizardPage/Components/PagePreparation/PagePreparation.tsx
+++ b/src/Routes/WizardPage/Components/PagePreparation/PagePreparation.tsx
@@ -4,7 +4,7 @@ import { Alert, Button, ClipboardCopy, Form, FormGroup, TextContent, Title } fro
 
 import './PagePreparation.scss';
 import { ResourcesApiFactory } from '../../../../Api';
-import { AppContext, AppContextType } from '../../../../AppContext';
+import { AppContext } from '../../../../AppContext';
 
 /** Represent the properties for PagePreparation component. */
 interface PagePreparationProps {
@@ -30,7 +30,7 @@ const PagePreparation = (props: PagePreparationProps) => {
   const prerequisitesLink = 'https://www.google.com?q=rhel-idm+pre-requisites';
 
   // States
-  const appContext = useContext<AppContextType | undefined>(AppContext);
+  const appContext = useContext(AppContext);
 
   const base_url = '/api/idmsvc/v1';
   const resources_api = ResourcesApiFactory(undefined, base_url, undefined);


### PR DESCRIPTION
**fix(HMS-4023): paging and reduce number of API requests**

Before, to load data for list page the UI did:
- 2x `domains?offest=0&limit=10` call
- a `readDomain` call for each returned domain

I.e. max 22 calls if the account has 10+ domains or
4 calls with a single domain.

Another issue was that the order of displayed domains was not stable.
Domains were added to appContext domain in order of finishing
asynchronous request. Thus it changed on each refresh.

Paging did not work as setting page and perPage was not propagated
well to the API call.

Now there is only single `domains?offset=$offset&limit=$pageSize` call
as this call returns all the data required for list page.

AppContext was extended to tracked results from `readDomain` and from
`domains` call separately. But `updateDomain`, `deleteDomain` calls were
changed so that they would update both list - to reflect deletion or
enable/disable of domain right away without reload of domains.


**fix: harden details page**

To handle when:
- domain is not in appContext

To navigate to domains list when:
- domain id is not supplied
- domain id is not for valid domain

A prep for HMS-4023