### PR TITLE
feat(HMS-2998): notifications for edit / delete / change auto-join

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,10 +14,10 @@ const App = () => {
   const navigate = useNavigate();
   const { on } = useChrome();
 
-  useEffect(() => {
-    const registry = getRegistry();
-    registry.register({ notifications: notificationsReducer as Reducer });
+  const registry = getRegistry();
+  registry.register({ notifications: notificationsReducer as Reducer });
 
+  useEffect(() => {
     const unregister = on('APP_NAVIGATION', (event) => navigate(`/${event.navId}`));
     return () => {
       unregister?.();

--- a/src/Components/DomainList/DomainList.tsx
+++ b/src/Components/DomainList/DomainList.tsx
@@ -9,6 +9,8 @@ import { AppContext, AppContextType } from '../../AppContext';
 import { Button } from '@patternfly/react-core';
 import AutoJoinChangeConfirmDialog from '../AutoJoinChangeConfirmDialog/AutoJoinChangeConfirmDialog';
 import ConfirmDeleteDomain from '../ConfirmDeleteDomain/ConfirmDeleteDomain';
+import useNotification from '../../Hooks/useNotification';
+import { buildDeleteFailedNotification, buildDeleteSuccessNotification } from '../../Routes/DetailPage/detailNotifications';
 
 export interface IColumnType<T> {
   key: string;
@@ -95,6 +97,7 @@ export const DomainList = () => {
 
   const context = useContext<AppContextType>(AppContext);
   const navigate = useNavigate();
+  const { notifyError, notifySuccess } = useNotification();
 
   // Index of the currently sorted column
   // Note: if you intend to make columns reorderable, you may instead want to use a non-numeric key
@@ -183,13 +186,14 @@ export const DomainList = () => {
         .then((response) => {
           if (response.status == 204) {
             removeDomain(domainId);
+            notifySuccess(buildDeleteSuccessNotification(domain));
           } else {
-            // TODO show-up notification with error message
+            notifyError(buildDeleteFailedNotification(domain));
           }
         })
         .catch((error) => {
-          // TODO show-up notification with error message
-          console.log('error onClose: ' + error);
+          notifyError(buildDeleteFailedNotification(domain));
+          console.log('error onDelete: ' + error);
         });
     }
   };

--- a/src/Components/DomainList/DomainList.tsx
+++ b/src/Components/DomainList/DomainList.tsx
@@ -10,7 +10,12 @@ import { Button } from '@patternfly/react-core';
 import AutoJoinChangeConfirmDialog from '../AutoJoinChangeConfirmDialog/AutoJoinChangeConfirmDialog';
 import ConfirmDeleteDomain from '../ConfirmDeleteDomain/ConfirmDeleteDomain';
 import useNotification from '../../Hooks/useNotification';
-import { buildDeleteFailedNotification, buildDeleteSuccessNotification } from '../../Routes/DetailPage/detailNotifications';
+import {
+  buildAutoJoinToggleFailedNotification,
+  buildAutoJoinToggleSuccessNotification,
+  buildDeleteFailedNotification,
+  buildDeleteSuccessNotification,
+} from '../../Routes/DetailPage/detailNotifications';
 
 export interface IColumnType<T> {
   key: string;
@@ -157,13 +162,14 @@ export const DomainList = () => {
         .then((response) => {
           if (response.status == 200) {
             context.updateDomain(response.data);
+            notifySuccess(buildAutoJoinToggleSuccessNotification(domain));
           } else {
-            // TODO show-up notification with error message
+            notifyError(buildAutoJoinToggleFailedNotification(domain));
           }
         })
         .catch((error) => {
-          // TODO show-up notification with error message
-          console.log('error onClose: ' + error);
+          notifyError(buildAutoJoinToggleFailedNotification(domain));
+          console.log('error toggleAutoJoin: ' + error);
         });
     }
   };

--- a/src/Hooks/useNotification.tsx
+++ b/src/Hooks/useNotification.tsx
@@ -1,0 +1,25 @@
+import { AlertVariant } from '@patternfly/react-core';
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+export interface NotificationPayload {
+  title: React.ReactNode | string;
+  variant?: AlertVariant;
+  description?: React.ReactNode | string;
+  id?: string | number;
+  dismissable?: boolean;
+}
+
+export default function useNotification() {
+  const dispatch = useDispatch();
+  const notify = (payload: NotificationPayload & { variant: AlertVariant }) => dispatch(addNotification(payload));
+
+  const notifyError = (payload: NotificationPayload) => notify({ variant: AlertVariant.danger, ...payload });
+
+  const notifySuccess = (payload: NotificationPayload) => notify({ variant: AlertVariant.success, ...payload });
+
+  const notifyWarning = (payload: NotificationPayload) => notify({ variant: AlertVariant.warning, ...payload });
+
+  return { notify, notifyError, notifySuccess, notifyWarning };
+}

--- a/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
+++ b/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
@@ -271,7 +271,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           </Button>,
         ]}
       >
-        <TextInput value={editTitle} type="text" onChange={(value) => setEditTitle(value)} ouiaId="TextModalDomainTitle" />
+        <TextInput value={editTitle} type="text" onChange={(value) => setEditTitle(value)} ouiaId="TextModalDomainTitle" aria-label="New Title" />
       </Modal>
       <Modal
         variant={ModalVariant.small}
@@ -294,7 +294,13 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           </Button>,
         ]}
       >
-        <TextArea autoResize resizeOrientation="vertical" value={editDescription} onChange={(value) => setEditDescription(value)} />
+        <TextArea
+          autoResize
+          resizeOrientation="vertical"
+          value={editDescription}
+          onChange={(value) => setEditDescription(value)}
+          aria-label="New Description"
+        />
       </Modal>
     </>
   );

--- a/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
+++ b/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
@@ -16,8 +16,15 @@ import {
 import React from 'react';
 import { useState } from 'react';
 import { Domain, ResourcesApiFactory } from '../../../../Api';
+import useNotification from '../../../../Hooks/useNotification';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
+import {
+  buildDescriptionEditFailedNotification,
+  buildDescriptionEditSuccessNotification,
+  buildTitleEditFailedNotification,
+  buildTitleEditSuccessNotification,
+} from '../../detailNotifications';
 
 interface DetailGeneralProps {
   domain?: Domain;
@@ -33,6 +40,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
 
   const base_url = '/api/idmsvc/v1';
   const resources_api = ResourcesApiFactory(undefined, base_url, undefined);
+  const { notifyError, notifySuccess } = useNotification();
 
   // States
   const [autoJoin, setAutoJoin] = useState<boolean | undefined>(domain.auto_enrollment_enabled);
@@ -57,12 +65,13 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           if (response.status == 200) {
             setTitle(response.data.title || '');
             if (props.onChange !== undefined) props.onChange({ ...domain, title: response.data.title });
+            notifySuccess(buildTitleEditSuccessNotification());
           } else {
-            // TODO show-up notification with error message
+            notifyError(buildTitleEditFailedNotification());
           }
         })
         .catch((error) => {
-          // TODO show-up notification with error message
+          notifyError(buildTitleEditFailedNotification());
           console.log('error at handleSaveTitleButton: ' + error);
         });
     }
@@ -85,12 +94,13 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
           if (response.status == 200) {
             setDescription(response.data.description || '');
             if (props.onChange !== undefined) props.onChange({ ...domain, description: response.data.description });
+            notifySuccess(buildDescriptionEditSuccessNotification());
           } else {
-            // TODO show-up notification with error message
+            notifyError(buildDescriptionEditFailedNotification());
           }
         })
         .catch((error) => {
-          // TODO show-up notification with error message
+          notifyError(buildDescriptionEditFailedNotification());
           console.log('error at handleSaveDescriptionButton: ' + error);
         });
     }

--- a/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
+++ b/src/Routes/DetailPage/Components/DetailGeneral/DetailGeneral.tsx
@@ -20,6 +20,7 @@ import useNotification from '../../../../Hooks/useNotification';
 import OutlinedQuestionCircleIcon from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import PencilAltIcon from '@patternfly/react-icons/dist/esm/icons/pencil-alt-icon';
 import {
+  buildAutoJoinToggleFailedNotification,
   buildDescriptionEditFailedNotification,
   buildDescriptionEditSuccessNotification,
   buildTitleEditFailedNotification,
@@ -112,7 +113,7 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
     setIsDescriptionModalOpen(false);
   };
 
-  const handleAutoJoin = (checked: boolean, event: React.FormEvent<HTMLInputElement>) => {
+  const handleAutoJoin = () => {
     console.log('toggled auto-join enable/disable');
     if (domain.domain_id) {
       resources_api
@@ -124,12 +125,12 @@ export const DetailGeneral = (props: DetailGeneralProps) => {
             setAutoJoin(response.data.auto_enrollment_enabled);
             if (props.onChange !== undefined) props.onChange({ ...domain, auto_enrollment_enabled: response.data.auto_enrollment_enabled });
           } else {
-            // TODO show-up notification with error message
+            notifyError(buildAutoJoinToggleFailedNotification(domain));
           }
         })
         .catch((error) => {
-          // TODO show-up notification with error message
-          console.log('error onClose: ' + error);
+          notifyError(buildAutoJoinToggleFailedNotification(domain));
+          console.log('error handleAutoJoin: ' + error);
         });
     }
   };

--- a/src/Routes/DetailPage/DetailPage.tsx
+++ b/src/Routes/DetailPage/DetailPage.tsx
@@ -23,6 +23,8 @@ import { AppContext } from '../../AppContext';
 import { DetailGeneral } from './Components/DetailGeneral/DetailGeneral';
 import { DetailServers } from './Components/DetailServers/DetailServers';
 import ConfirmDeleteDomain from '../../Components/ConfirmDeleteDomain/ConfirmDeleteDomain';
+import useNotification from '../../Hooks/useNotification';
+import { buildDeleteFailedNotification, buildDeleteSuccessNotification } from './detailNotifications';
 
 /**
  * It represents the detail page to show the information about a
@@ -35,6 +37,7 @@ const DetailPage = () => {
   const base_url = '/api/idmsvc/v1';
   const resources_api = ResourcesApiFactory(undefined, base_url, undefined);
   const navigate = useNavigate();
+  const { notifyError, notifySuccess } = useNotification();
 
   // Params
   const { domain_id } = useParams();
@@ -101,15 +104,18 @@ const DetailPage = () => {
         .then((response) => {
           if (response.status == 204) {
             appContext?.deleteDomain(domainId);
+            notifySuccess(buildDeleteSuccessNotification(domain));
             navigate('/domains', { replace: true });
           } else {
-            // TODO show-up notification with error message
+            notifyError(buildDeleteFailedNotification(domain));
             console.error(`response.status=${response.status}; response.data=${response.data}`);
+            onDismissConfirmDelete();
           }
         })
         .catch((error) => {
-          // TODO show-up notification with error message
-          console.log('error onClose: ' + error);
+          notifyError(buildDeleteFailedNotification(domain));
+          console.log('error onDelete: ' + error);
+          onDismissConfirmDelete();
         });
     }
   };

--- a/src/Routes/DetailPage/detailNotifications.tsx
+++ b/src/Routes/DetailPage/detailNotifications.tsx
@@ -1,0 +1,17 @@
+import { NotificationPayload } from '../../Hooks/useNotification';
+
+export const buildDescriptionEditSuccessNotification = (): NotificationPayload => {
+  return { title: 'Identity domain description edited.' };
+};
+
+export const buildDescriptionEditFailedNotification = (): NotificationPayload => {
+  return { title: 'Identity domain description could not be edited.' };
+};
+
+export const buildTitleEditSuccessNotification = (): NotificationPayload => {
+  return { title: 'Identity domain title edited.' };
+};
+
+export const buildTitleEditFailedNotification = (): NotificationPayload => {
+  return { title: 'Identity domain title could not be edited.' };
+};

--- a/src/Routes/DetailPage/detailNotifications.tsx
+++ b/src/Routes/DetailPage/detailNotifications.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+
+import { Domain } from '../../Api/api';
 import { NotificationPayload } from '../../Hooks/useNotification';
 
 export const buildDescriptionEditSuccessNotification = (): NotificationPayload => {
@@ -14,4 +17,24 @@ export const buildTitleEditSuccessNotification = (): NotificationPayload => {
 
 export const buildTitleEditFailedNotification = (): NotificationPayload => {
   return { title: 'Identity domain title could not be edited.' };
+};
+
+export const buildDeleteSuccessNotification = (domain?: Domain): NotificationPayload => {
+  return {
+    title: (
+      <>
+        Domain <i>{domain?.title}</i> deleted successfully.
+      </>
+    ),
+  };
+};
+
+export const buildDeleteFailedNotification = (domain?: Domain): NotificationPayload => {
+  return {
+    title: (
+      <>
+        Failed to delete domain <i>{domain?.title}</i>
+      </>
+    ),
+  };
 };

--- a/src/Routes/DetailPage/detailNotifications.tsx
+++ b/src/Routes/DetailPage/detailNotifications.tsx
@@ -38,3 +38,23 @@ export const buildDeleteFailedNotification = (domain?: Domain): NotificationPayl
     ),
   };
 };
+
+export const buildAutoJoinToggleSuccessNotification = (domain?: Domain): NotificationPayload => {
+  return {
+    title: (
+      <>
+        Domain auto-join for <i>{domain?.title}</i> updated successfully.
+      </>
+    ),
+  };
+};
+
+export const buildAutoJoinToggleFailedNotification = (domain?: Domain): NotificationPayload => {
+  return {
+    title: (
+      <>
+        Failed to update domain auto-join for <i>{domain?.title}.</i>
+      </>
+    ),
+  };
+};


### PR DESCRIPTION
This PR implements bit more than HMS-2998 says, but in the end it's all about notifying edits of identity domains.

**refactor: useNotification hook**

Add an utility hook which provides easy-to use methods for displaying
notifications via `<NotificationsPortal />`.

Prep for: HMS-2997, HMS-2998

**feat(HMS-2998): domain edit notifications**

Add notifications for reporting success or error when domain description
or title are edited.
   
**fix: missing aria-title attributes in domain edit**

The missing attrs were reported in browser console. The UI is also more
accessible with them.

**feat: domain deletion notifications**

Show notification on successful or failed deletion of domain.
Improves UX.

**feat: domain auto-join change notifications**

Show notification on successful or failed change of domain auto-launch.
Improves UX.

**fix: showing notification on page transitions**

There is a bug that after some page transitions notifications did not
appear, but they appeared later in bulk when page was changed to some
other. This change seems to fix it, though I don't fully understand if
it is a correct fix.


Demo video: https://drive.google.com/file/d/1oUYlNxiF2ZD21OY8xIwzPnBwnwpnccY3/view?usp=drive_link 
