### PR TITLE
feat(HMS-2997): wizard notifications

### DIFF
--- a/src/Hooks/useNotification.tsx
+++ b/src/Hooks/useNotification.tsx
@@ -1,5 +1,5 @@
 import { AlertVariant } from '@patternfly/react-core';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+import { addNotification, removeNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import React from 'react';
 import { useDispatch } from 'react-redux';
 
@@ -21,5 +21,7 @@ export default function useNotification() {
 
   const notifyWarning = (payload: NotificationPayload) => notify({ variant: AlertVariant.warning, ...payload });
 
-  return { notify, notifyError, notifySuccess, notifyWarning };
+  const remove = (id: string | number) => dispatch(removeNotification(id));
+
+  return { notify, notifyError, notifySuccess, notifyWarning, removeNotification: remove };
 }


### PR DESCRIPTION
Added notifications for cancelling and finishing a wizard.

The notification for cancel is a bit different then drafted in
HMS-2997 as the cancellation process is removing the registered
domain so in most cases it should end with the same result.

Rebased on top of https://github.com/podengo-project/idmsvc-frontend/pull/55 

Demo: https://drive.google.com/file/d/1wj6n70VCWuHjensaz_JqM6hh6uze5BE8/view?usp=drive_link

In the demo we can see that the notifications did not disappear in some cases.  I think this is connected with the way how the notification middleware/redux store is registered + navigation between pages. But I don't have a fix for it yet. Commit https://github.com/podengo-project/idmsvc-frontend/commit/463f9a82305d9af43d27851d34ed3074484a7aa6 had some possitive effect in pr 55 but not much in the registration workflow.

