### PR TITLE
fix(HMS-4059): notifications navigation issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,15 @@
 import React, { Fragment, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Reducer } from 'redux';
 
 import DomainRegistryRoutes from './Routes';
 import './App.scss';
 
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 const App = () => {
   const navigate = useNavigate();
   const { on } = useChrome();
-
-  const registry = getRegistry();
-  registry.register({ notifications: notificationsReducer as Reducer });
 
   useEffect(() => {
     const unregister = on('APP_NAVIGATION', (event) => navigate(`/${event.navId}`));

--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import { init } from './store';
+import { initStore, restoreStore } from './store';
 import App from './App';
 import { getBaseName } from '@redhat-cloud-services/frontend-components-utilities/helpers';
-import logger from 'redux-logger';
+
 import { AppContextProvider } from './AppContext';
 
 const AppEntry = () => {
+  const store = React.useMemo(() => {
+    restoreStore();
+    return initStore();
+  }, []);
+
   return (
-    <Provider store={init(...(process.env.NODE_ENV !== 'production' ? [logger] : [])).getStore()}>
+    <Provider store={store} stabilityCheck="always">
       <Router basename={getBaseName(window.location.pathname)}>
         <AppContextProvider>
           <App />

--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -29,11 +29,10 @@ import { AppContext } from '../../AppContext';
 import { VerifyState } from './Components/VerifyRegistry/VerifyRegistry';
 import useNotification from '../../Hooks/useNotification';
 
-// Lazy load for the wizard pages
-const PagePreparation = React.lazy(() => import('./Components/PagePreparation/PagePreparation'));
-const PageServiceRegistration = React.lazy(() => import('./Components/PageServiceRegistration/PageServiceRegistration'));
-const PageServiceDetails = React.lazy(() => import('./Components/PageServiceDetails/PageServiceDetails'));
-const PageReview = React.lazy(() => import('./Components/PageReview/PageReview'));
+import PagePreparation from './Components/PagePreparation/PagePreparation';
+import PageServiceRegistration from './Components/PageServiceRegistration/PageServiceRegistration';
+import PageServiceDetails from './Components/PageServiceDetails/PageServiceDetails';
+import PageReview from './Components/PageReview/PageReview';
 
 /**
  * Wizard page to register a new domain into the service.

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,13 +1,27 @@
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
+import { Middleware, Store } from 'redux';
 import promiseMiddleware from 'redux-promise-middleware';
-import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
-import ReducerRegistry from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
-import { Middleware } from 'redux';
+import logger from 'redux-logger';
+
+import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
+import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export let registry: ReducerRegistry<any>; // FIXME Avoid any
+let registry: any;
 
-export function init(...middleware: Middleware[]) {
-  registry = getRegistry({}, [promiseMiddleware, notificationsMiddleware({ errorDescriptionKey: ['detail', 'stack'] }), ...middleware]);
-  return registry;
+export const restoreStore = () => {
+  registry = undefined;
+};
+
+export function initStore(): Store {
+  if (registry) {
+    throw new Error('store already initialized');
+  }
+
+  const middleware: Middleware[] = [promiseMiddleware];
+  if (process.env.NODE_ENV !== 'production') {
+    middleware.push(logger);
+  }
+  registry = getRegistry({}, middleware);
+  registry.register({ notifications: notificationsReducer });
+  return registry.getStore();
 }


### PR DESCRIPTION
**fix: redux store configuration**

Adjust the configuration to run store initialization and reducer
registration only once on one place.

**fix(HMS-4059): notifications navigation issues**
  
Notifications stopped working well when using wizard. The issue
seems to be that `useSelector` hook, that is used in `NotificationsPortal`,
stopped reacting to state changes and thus the notifications "stopped"
working well.

The situation looks to be gone after removing the lazy load of wizard pages.

This also improves a bit perceived responsiveness when already in the app
as the wizard pages are displayed right after navigating to them as there
is no load.

Removing the load should also be OK from code splitting perspective as
the pages are not big and thus could be part of the main app.