### PR TITLE
fix(HMS-4061): fix auto enrollment

### DIFF
--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -237,6 +237,7 @@ const WizardPage = () => {
     }
     appContext?.wizard.setRegisteredStatus(value);
     if (value === 'completed' && data !== undefined) {
+      data.auto_enrollment_enabled = true;
       appContext?.wizard.setDomain(data);
       setCanJumpPage3(true);
       // Check whether initial values for user-configurable fields


### PR DESCRIPTION
When the domain is registered on the backend, it is created with autoenrollment disabled (https://github.com/podengo-project/idmsvc-backend/pull/198/files).

When the verification happens on the frontend, the returned value is false, but we want to set by default for the UI enabled. This change is not effective until the user finish the wizard and click the Finish button, and at that time the PATCH /domains/:domain_id is sent and whatever that the user decided (leave disabled, or enabled) is then set on the backend side.

DRAFT: until it is reviewed the ipa-hcc pipeline don't get broken by: https://github.com/podengo-project/idmsvc-backend/pull/198/files