### PR TITLE
test: add npm run test-watch target

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "patch:hosts": "fec patch-etc-hosts",
     "start": "HOT=true fec dev",
     "test": "TZ=UTC jest --verbose --no-cache",
+    "test-watch": "TZ=UTC jest --watch",
     "postinstall": "rimraf .cache",
     "prettier": "prettier --write src",
     "verify": "npm-run-all build lint test",


### PR DESCRIPTION
Which calls `jest --watch`. This is useful for development of unit tests. On save of modified file, unit tests related to the changed file are executed.