### PR TITLE
ci(HMS-4082): fail eslint on warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "fec build",
     "deploy": "npm-run-all build lint test",
     "lint": "npm-run-all lint:*",
-    "lint:js": "eslint config src",
+    "lint:js": "eslint --max-warnings 0 config src",
     "lint:js:fix": "eslint config src --fix",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
     "lint:prettier": "prettier --check src",


### PR DESCRIPTION
To prevent introduction of new TypeScript lint warnings in the codebase.