### PR TITLE
feat(HMS-2721): integrate check permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ make dev-static port=9999
 
 The below will be necessary to deploy on the dev cluster.
 
+- Install nvm by: `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash`.
+- Config node 18 by: `nvm install 18; nvm use 18`.
 - Run `cp -vf config/bonfire.example.yaml config/bonfire.yaml`.
 - Update the `config/bonfire.yaml` file by following the TODO
   placeholders.

--- a/src/AppContext.tsx
+++ b/src/AppContext.tsx
@@ -2,6 +2,7 @@ import { ReactNode, createContext, useState } from 'react';
 import { Domain } from './Api/idmsvc';
 import { VerifyState } from './Routes/WizardPage/Components/VerifyRegistry/VerifyRegistry';
 import React from 'react';
+import useIdmPermissions, { IdmPermissions } from './Hooks/useIdmPermissions';
 
 /**
  * It represents the application context so common events and properties
@@ -50,6 +51,7 @@ export interface AppContextType {
     /** Set the ephemeral domain information. */
     setDomain: (value: Domain) => void;
   };
+  rbac: IdmPermissions;
 }
 
 /**
@@ -76,6 +78,7 @@ export const AppContext = createContext<AppContextType>({
     domain: {} as Domain,
     setDomain: () => undefined,
   },
+  rbac: {} as IdmPermissions,
 });
 
 /**
@@ -179,6 +182,7 @@ export const AppContextProvider: React.FC<AppContextProviderProps> = ({ children
           domain: wizardDomain || ({} as Domain),
           setDomain: _setWizardDomain,
         },
+        rbac: useIdmPermissions(),
       }}
     >
       {children}

--- a/src/Hooks/useIdmPermissions.tsx
+++ b/src/Hooks/useIdmPermissions.tsx
@@ -1,0 +1,42 @@
+import { usePermissions } from '@redhat-cloud-services/frontend-components-utilities/RBACHook';
+
+const APP = 'idmsvc';
+
+export interface IdmPermissions {
+  isLoading: boolean;
+  permissions: {
+    hasTokenCreate: boolean | undefined;
+    hasDomainsRead: boolean | undefined;
+    hasDomainsList: boolean | undefined;
+    hasDomainsUpdate: boolean | undefined;
+    hasDomainsDelete: boolean | undefined;
+  };
+}
+
+/**
+ * @returns useIdmPermissions encapsulate the permissions for
+ * domain integration service.
+ */
+const useIdmPermissions = (): IdmPermissions => {
+  const { hasAccess: hasTokensCreate, isLoading: isLoadingTokensCreate } = usePermissions(APP, [APP + ':token:create'], false, true);
+  const { hasAccess: hasDomainsRead, isLoading: isLoadingDomainsRead } = usePermissions(APP, [APP + ':domains:read'], false, true);
+  const { hasAccess: hasDomainsUpdate, isLoading: isLoadingDomainsUpdate } = usePermissions(APP, [APP + ':domains:update'], false, true);
+  const { hasAccess: hasDomainsDelete, isLoading: isLoadingDomainsDelete } = usePermissions(APP, [APP + ':domains:delete'], false, true);
+  const { hasAccess: hasDomainsList, isLoading: isLoadingDomainsList } = usePermissions(APP, [APP + ':domains:list'], false, true);
+
+  const isLoading: boolean =
+    isLoadingTokensCreate || isLoadingDomainsRead || isLoadingDomainsUpdate || isLoadingDomainsDelete || isLoadingDomainsList;
+
+  return {
+    isLoading: isLoading,
+    permissions: {
+      hasTokenCreate: hasTokensCreate,
+      hasDomainsRead: hasDomainsRead,
+      hasDomainsList: hasDomainsList,
+      hasDomainsUpdate: hasDomainsUpdate,
+      hasDomainsDelete: hasDomainsDelete,
+    },
+  };
+};
+
+export default useIdmPermissions;


### PR DESCRIPTION
This change is build on top of #64.

This change provide the specific hook to check
the idmsvc permissions so this can be used
broadly on the whole UI.

