### PR TITLE
feat(HMS-4156): confirmation checkbox in delete domain confirm modal

### DIFF
--- a/src/Components/ConfirmDeleteDomain/ConfirmDeleteDomain.test.tsx
+++ b/src/Components/ConfirmDeleteDomain/ConfirmDeleteDomain.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
 import ConfirmDeleteDomain from './ConfirmDeleteDomain';
 import '@testing-library/jest-dom';
@@ -21,7 +21,7 @@ test('expect modal displayed', () => {
   expect(screen.getByRole('button', { name: 'Cancel' })).toHaveTextContent(/^Cancel$/);
 });
 
-test('expect handler onDelete to be called', () => {
+test('expect handler onDelete to not be called without confirmation', () => {
   // given
   const confirmHandler = jest.fn();
   const cancelHandler = jest.fn();
@@ -31,8 +31,30 @@ test('expect handler onDelete to be called', () => {
   screen.getByRole('button', { name: 'Delete' }).click();
 
   // then the confirmHandler should be called with the domain as argument and cancelHandler should not
-  expect(confirmHandler).toBeCalledWith(domain);
-  expect(cancelHandler).toBeCalledTimes(0);
+  expect(confirmHandler).toHaveBeenCalledTimes(0);
+  expect(cancelHandler).toHaveBeenCalledTimes(0);
+});
+
+test('expect handler onDelete is called with confirmation', () => {
+  // given
+  const confirmHandler = jest.fn();
+  const cancelHandler = jest.fn();
+  render(<ConfirmDeleteDomain domain={domain} isOpen={true} onDelete={confirmHandler} onCancel={cancelHandler} />);
+
+  // when confirmation checkbox is checked
+  const checkbox = screen.getByRole('checkbox', { name: 'I understand that this action cannot be undone' });
+  expect(checkbox).not.toBeChecked();
+  act(() => {
+    checkbox.click();
+  });
+  expect(checkbox).toBeChecked();
+
+  // when the OK button is clicked
+  screen.getByRole('button', { name: 'Delete' }).click();
+
+  // then the confirmHandler should be called with the domain as argument and cancelHandler should not
+  expect(confirmHandler).toHaveBeenCalledWith(domain);
+  expect(cancelHandler).toHaveBeenCalledTimes(0);
 });
 
 test('expect handler onCancel to be called', () => {
@@ -45,6 +67,6 @@ test('expect handler onCancel to be called', () => {
   screen.getByRole('button', { name: 'Cancel' }).click();
 
   // then the confirmHandler should be called with the domain as argument and cancelHandler should not
-  expect(cancelHandler).toBeCalledTimes(1);
-  expect(confirmHandler).toBeCalledTimes(0);
+  expect(cancelHandler).toHaveBeenCalledTimes(1);
+  expect(confirmHandler).toHaveBeenCalledTimes(0);
 });

--- a/src/Components/ConfirmDeleteDomain/ConfirmDeleteDomain.tsx
+++ b/src/Components/ConfirmDeleteDomain/ConfirmDeleteDomain.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal } from '@patternfly/react-core';
+import { Button, Checkbox, Modal } from '@patternfly/react-core';
 import './ConfirmDeleteDomain.scss';
 import React from 'react';
 import { Domain } from '../../Api/idmsvc';
@@ -16,6 +16,8 @@ interface ConfirmDeleteDomainProps {
  * @param props the props given by the smart component.
  */
 const ConfirmDeleteDomain: React.FC<ConfirmDeleteDomainProps> = (props) => {
+  const [isConfirmed, setIsConfirmed] = React.useState(false);
+
   const onDeleteWrapper = () => {
     props.onDelete && props.onDelete(props.domain);
   };
@@ -28,7 +30,7 @@ const ConfirmDeleteDomain: React.FC<ConfirmDeleteDomainProps> = (props) => {
       ouiaId="ModalConfirmDeletion"
       onClose={props.onCancel}
       actions={[
-        <Button key="delete" variant="danger" onClick={onDeleteWrapper} ouiaId="ButtonModalConfirmDeletionDelete">
+        <Button key="delete" variant="danger" onClick={onDeleteWrapper} isDisabled={!isConfirmed} ouiaId="ButtonModalConfirmDeletionDelete">
           Delete
         </Button>,
         <Button key="cancel" variant="link" onClick={props.onCancel} ouiaId="ButtonModalConfirmDeletionCancel">
@@ -38,6 +40,14 @@ const ConfirmDeleteDomain: React.FC<ConfirmDeleteDomainProps> = (props) => {
     >
       Hosts will be unable to automatically join the domain
       <b> {props.domain?.title || ''}</b> after deletion.
+      <Checkbox
+        label="I understand that this action cannot be undone"
+        isChecked={isConfirmed}
+        onChange={(_event, value) => setIsConfirmed(value)}
+        id="confirm-delete-domain-checkbox"
+        name="confirm-delete-domain-checkbox"
+        className="pf-v5-u-mt-lg"
+      />
     </Modal>
   );
 };


### PR DESCRIPTION
Add confirmation checkbox that enables delete button to warn user that the action cannot be undone.

In unit test, some jest calls were replaced by newer variants as the older were deprecated.

![image](https://github.com/podengo-project/idmsvc-frontend/assets/5136843/5850c5da-9a1e-4b49-97b9-c3ad480f7993)

![image](https://github.com/podengo-project/idmsvc-frontend/assets/5136843/656b58bc-e943-4638-853e-681199a81de2)
