### PR TITLE
fix(HMS-4080): next step enablement in wizard

### DIFF
--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -258,6 +258,9 @@ const WizardPage = () => {
               navItem={{
                 content: 'Preparation',
               }}
+              footer={{
+                isNextDisabled: !canJumpPage2,
+              }}
             >
               <PagePreparation onToken={onToken} />
             </WizardStep>
@@ -268,6 +271,9 @@ const WizardPage = () => {
               navItem={{
                 content: 'Registration',
               }}
+              footer={{
+                isNextDisabled: !canJumpPage3,
+              }}
             >
               <PageServiceRegistration uuid={domain?.domain_id ? domain?.domain_id : ''} token={appContext?.wizard.token || ''} onVerify={onVerify} />
             </WizardStep>
@@ -277,6 +283,9 @@ const WizardPage = () => {
               isDisabled={!canJumpPage3}
               navItem={{
                 content: 'Details',
+              }}
+              footer={{
+                isNextDisabled: !canJumpPage4,
               }}
             >
               <PageServiceDetails


### PR DESCRIPTION
Refactoring done in 45af0c949f35004e780625b323f187066ade8352 in context of HMS-4080 introduced a regression where disabling/enabling of "next" step in wizard stopped working. Thus user could navigate from step 2 to 3 without registering the domain. This lead to further issues.

This commit is fixing the issue - bringing the old behavior back.