### PR TITLE
feat(HMS-2721): check rbac on loading pages

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -19,6 +19,9 @@ module.exports = {
     '/api/idmsvc/': { host: 'http://localhost:8000' },
 
     /* Add routes to the chrome-service*/
-    /* '/api/chrome-service/v1/static/': { host: 'http://localhost:9999' }, */
+    // '/api/chrome-service/v1/static/': { host: 'http://localhost:9999' },
+
+    /* Add routes to the rbac mock server */
+    '/api/rbac/v1/access/': { host: 'http://localhost:8020' },
   },
 };

--- a/src/Components/CenteredSpinner/CenteredSpinner.test.tsx
+++ b/src/Components/CenteredSpinner/CenteredSpinner.test.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import CenteredSpinner from './CenteredSpinner';
+import '@testing-library/jest-dom';
+
+test('expect CenteredSpinner to render', () => {
+  render(<CenteredSpinner />);
+});

--- a/src/Components/CenteredSpinner/CenteredSpinner.tsx
+++ b/src/Components/CenteredSpinner/CenteredSpinner.tsx
@@ -1,0 +1,16 @@
+import { Bullseye, Spinner } from '@patternfly/react-core';
+import React from 'react';
+
+/**
+ * Component to show a Spineer centered in the available fragment
+ * of the screen.
+ */
+const CenteredSpinner = () => {
+  return (
+    <Bullseye>
+      <Spinner />
+    </Bullseye>
+  );
+};
+
+export default CenteredSpinner;

--- a/src/Hooks/useIdmPermissions.tsx
+++ b/src/Hooks/useIdmPermissions.tsx
@@ -18,11 +18,17 @@ export interface IdmPermissions {
  * domain integration service.
  */
 const useIdmPermissions = (): IdmPermissions => {
-  const { hasAccess: hasTokensCreate, isLoading: isLoadingTokensCreate } = usePermissions(APP, [APP + ':token:create'], false, true);
-  const { hasAccess: hasDomainsRead, isLoading: isLoadingDomainsRead } = usePermissions(APP, [APP + ':domains:read'], false, true);
-  const { hasAccess: hasDomainsUpdate, isLoading: isLoadingDomainsUpdate } = usePermissions(APP, [APP + ':domains:update'], false, true);
-  const { hasAccess: hasDomainsDelete, isLoading: isLoadingDomainsDelete } = usePermissions(APP, [APP + ':domains:delete'], false, true);
-  const { hasAccess: hasDomainsList, isLoading: isLoadingDomainsList } = usePermissions(APP, [APP + ':domains:list'], false, true);
+  const tokenCreate = APP + ':token:create';
+  const domainsRead = APP + ':domains:read';
+  const domainsUpdate = APP + ':domains:update';
+  const domainsDelete = APP + ':domains:delete';
+  const domainsList = APP + ':domains:list';
+
+  const { hasAccess: hasTokensCreate, isLoading: isLoadingTokensCreate } = usePermissions(APP, [tokenCreate], true, true);
+  const { hasAccess: hasDomainsRead, isLoading: isLoadingDomainsRead } = usePermissions(APP, [domainsRead], true, true);
+  const { hasAccess: hasDomainsUpdate, isLoading: isLoadingDomainsUpdate } = usePermissions(APP, [domainsUpdate], true, true);
+  const { hasAccess: hasDomainsDelete, isLoading: isLoadingDomainsDelete } = usePermissions(APP, [domainsDelete], true, true);
+  const { hasAccess: hasDomainsList, isLoading: isLoadingDomainsList } = usePermissions(APP, [domainsList], true, true);
 
   const isLoading: boolean =
     isLoadingTokensCreate || isLoadingDomainsRead || isLoadingDomainsUpdate || isLoadingDomainsDelete || isLoadingDomainsList;

--- a/src/Routes/DetailPage/DetailPage.tsx
+++ b/src/Routes/DetailPage/DetailPage.tsx
@@ -27,6 +27,7 @@ import { DetailServers } from './Components/DetailServers/DetailServers';
 import ConfirmDeleteDomain from '../../Components/ConfirmDeleteDomain/ConfirmDeleteDomain';
 import useNotification from '../../Hooks/useNotification';
 import { buildDeleteFailedNotification, buildDeleteSuccessNotification } from './detailNotifications';
+import CenteredSpinner from '../../Components/CenteredSpinner/CenteredSpinner';
 
 /**
  * It represents the detail page to show the information about a
@@ -57,6 +58,9 @@ const DetailPage = () => {
 
   // Load Domain to display
   useEffect(() => {
+    if (!appContext.rbac.permissions.hasDomainsRead) {
+      navigate('/no-permissions', { replace: true });
+    }
     if (domain_id) {
       resources_api
         .readDomain(domain_id)
@@ -72,7 +76,7 @@ const DetailPage = () => {
           navigate('/domains', { replace: true });
         });
     }
-  }, [domain_id]);
+  }, [domain_id, appContext.rbac.isLoading]);
 
   // Kebab menu
   const [isKebabOpen, setIsKebabOpen] = useState<boolean>(false);
@@ -114,6 +118,10 @@ const DetailPage = () => {
   const handleTabClick = (event: React.MouseEvent<HTMLElement, MouseEvent>, tabIndex: string | number) => {
     setActiveTabKey(tabIndex);
   };
+
+  if (appContext.rbac.isLoading) {
+    return <CenteredSpinner />;
+  }
 
   // Return render
   return (

--- a/src/Routes/NoPermissionsPage/NoPermissionsPage.tsx
+++ b/src/Routes/NoPermissionsPage/NoPermissionsPage.tsx
@@ -2,15 +2,36 @@ import React, { useEffect } from 'react';
 
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
+import { Button } from '@patternfly/react-core';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const NoPermissionsPage = () => {
   useEffect(() => {
     insights?.chrome?.appAction?.('no-permissions');
   }, []);
 
+  const { isBeta } = useChrome();
+  const prefix = isBeta() ? '/beta' : '/preview';
+  const linkMyUserAccess = prefix + '/iam/my-user-access';
+
   return (
     <Main>
-      <NotAuthorized serviceName="Sample app" />
+      <NotAuthorized
+        serviceName="Directory and Domain"
+        showReturnButton
+        title="Access permissions needed"
+        description={
+          <>
+            To access identity domains, contact your organization <br />
+            administrator. Aternatively, visit
+            <br />
+            <Button component="a" variant="link" isInline iconPosition="right" href={linkMyUserAccess} ouiaId="LinkNoPermissionsMyUserAccess">
+              My User Access
+            </Button>{' '}
+            to learn more about your permissions.
+          </>
+        }
+      />
     </Main>
   );
 };

--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -4,7 +4,7 @@
  * The goal is provide the steps to register and add
  * a new domain service.
  */
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
 import { Button, Modal, ModalVariant, PageGroup, PageSection, PageSectionVariants, Text, Wizard, WizardStep } from '@patternfly/react-core';
@@ -22,6 +22,7 @@ import PagePreparation from './Components/PagePreparation/PagePreparation';
 import PageServiceRegistration from './Components/PageServiceRegistration/PageServiceRegistration';
 import PageServiceDetails from './Components/PageServiceDetails/PageServiceDetails';
 import PageReview from './Components/PageReview/PageReview';
+import CenteredSpinner from '../../Components/CenteredSpinner/CenteredSpinner';
 
 /**
  * Wizard page to register a new domain into the service.
@@ -42,6 +43,13 @@ const WizardPage = () => {
   // FIXME Update the URL with the location for docs
   const linkLearnMoreAbout = 'https://access.redhat.com/articles/1586893';
   const linkLearnMoreAboutRemovingDirectoryAndDomainServices = 'https://access.redhat.com/articles/1586893';
+
+  useEffect(() => {
+    if (!appContext.rbac.permissions.hasTokenCreate || !appContext.rbac.permissions.hasDomainsUpdate) {
+      navigate('/no-permissions', { replace: true });
+      return;
+    }
+  }, [appContext.rbac.isLoading]);
 
   const notifyNotCompleted = () => {
     const notificationID = 'domain-registration-cancelled-notification';
@@ -227,6 +235,10 @@ const WizardPage = () => {
   };
 
   const title = 'Register identity domain';
+
+  if (appContext.rbac.isLoading) {
+    return <CenteredSpinner />;
+  }
 
   return (
     <>


### PR DESCRIPTION
This change integrate the rbac hook to check the
required permissions when we navigate to some
specific page, and if not enough permissions,
the user is redirected to the no-permissions
page.

out of scope: enable/disable controls dynamically
based on the current permissions.

Depends on: https://github.com/podengo-project/idmsvc-frontend/pull/65

TODO

- [x] Detect when to display "Return to previous page" or "Go to landing page" title for the no permissions page button. It is detected by the component.
- [x] `navigate` cannot be used or the `Return to previous page` won't work correctly, returning to the path that evoked the redirect to no-permissions. Fixed one effect; remaining an additional effect, evoking to return one page back the previous.