### PR TITLE
fix(HMS-4253): do not change url when missing RBAC permissions

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   coverageDirectory: './coverage/',
   moduleNameMapper: {
     '\\.(css|scss)$': 'identity-obj-proxy',
+    uuid: require.resolve('uuid'), // https://stackoverflow.com/a/73203803
   },
   roots: ['<rootDir>/src/'],
   transformIgnorePatterns: ['/node_modules/(?!@redhat-cloud-services)', '/node_modules/(?!@patternfly)'],

--- a/src/Components/NoPermissions/NoPermissions.test.tsx
+++ b/src/Components/NoPermissions/NoPermissions.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import NoPermissions from './NoPermissions';
+import '@testing-library/jest-dom';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
+  return () => ({
+    isBeta: () => true,
+  });
+});
+
+test('expect NoPermissions to render', () => {
+  const { container } = render(<NoPermissions />);
+  expect(container).toHaveTextContent('Access permissions needed');
+});

--- a/src/Components/NoPermissions/NoPermissions.tsx
+++ b/src/Components/NoPermissions/NoPermissions.tsx
@@ -1,21 +1,19 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 
-import { Main } from '@redhat-cloud-services/frontend-components/Main';
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
-import { Button } from '@patternfly/react-core';
+import { Button, PageSection } from '@patternfly/react-core';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-const NoPermissionsPage = () => {
-  useEffect(() => {
-    insights?.chrome?.appAction?.('no-permissions');
-  }, []);
-
+/**
+ * A Component to show when user doesn't have RBAC permissions for the page.
+ */
+const NoPermissions = () => {
   const { isBeta } = useChrome();
   const prefix = isBeta() ? '/beta' : '/preview';
   const linkMyUserAccess = prefix + '/iam/my-user-access';
 
   return (
-    <Main>
+    <PageSection>
       <NotAuthorized
         serviceName="Directory and Domain"
         showReturnButton
@@ -32,8 +30,8 @@ const NoPermissionsPage = () => {
           </>
         }
       />
-    </Main>
+    </PageSection>
   );
 };
 
-export default NoPermissionsPage;
+export default NoPermissions;

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,12 +1,10 @@
-import React, { lazy } from 'react';
+import React from 'react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import WizardPage from './Routes/WizardPage/WizardPage';
 import DetailPage from './Routes/DetailPage/DetailPage';
-
-const DefaultPage = lazy(() => import(/* webpackChunkName: "DefaultPage" */ './Routes/DefaultPage/DefaultPage'));
-const OopsPage = lazy(() => import(/* webpackChunkName: "OopsPage" */ './Routes/OopsPage/OopsPage'));
-const NoPermissionsPage = lazy(() => import(/* webpackChunkName: "NoPermissionsPage" */ './Routes/NoPermissionsPage/NoPermissionsPage'));
+import DefaultPage from './Routes/DefaultPage/DefaultPage';
+import OopsPage from './Routes/OopsPage/OopsPage';
 
 /**
  * the Switch component changes routes depending on the path.
@@ -22,7 +20,6 @@ const DomainRegistryRoutes = () => (
     <Route path="/details/:domain_id" Component={DetailPage} />
     <Route path="/domains/wizard" Component={WizardPage} />
     <Route path="/oops" Component={OopsPage} />
-    <Route path="/no-permissions" Component={NoPermissionsPage} />
     {/* Finally, catch all unmatched routes */}
     <Route path="*" element={<Navigate to="/domains" replace />} />
   </Routes>

--- a/src/Routes/DetailPage/DetailPage.tsx
+++ b/src/Routes/DetailPage/DetailPage.tsx
@@ -29,6 +29,7 @@ import useNotification from '../../Hooks/useNotification';
 import { buildDeleteFailedNotification, buildDeleteSuccessNotification } from './detailNotifications';
 import useIdmPermissions from '../../Hooks/useIdmPermissions';
 import CenteredSpinner from '../../Components/CenteredSpinner/CenteredSpinner';
+import NoPermissions from '../../Components/NoPermissions/NoPermissions';
 
 /**
  * It represents the detail page to show the information about a
@@ -43,6 +44,7 @@ const DetailPage = () => {
   const navigate = useNavigate();
   const { notifyError, notifySuccess } = useNotification();
   const rbac = useIdmPermissions();
+  const hasPermissions = !rbac.isLoading && rbac.permissions.hasDomainsRead;
 
   // Params
   const { domain_id } = useParams();
@@ -61,12 +63,7 @@ const DetailPage = () => {
 
   // Load Domain to display
   useEffect(() => {
-    if (rbac.isLoading) {
-      return;
-    }
-
-    if (!rbac.permissions.hasDomainsRead) {
-      navigate('/no-permissions', { replace: true });
+    if (!hasPermissions) {
       return;
     }
     if (domain_id) {
@@ -84,7 +81,7 @@ const DetailPage = () => {
           navigate('/domains', { replace: true });
         });
     }
-  }, [domain_id, rbac]);
+  }, [domain_id, hasPermissions]);
 
   // Kebab menu
   const [isKebabOpen, setIsKebabOpen] = useState<boolean>(false);
@@ -129,6 +126,10 @@ const DetailPage = () => {
 
   if (rbac.isLoading) {
     return <CenteredSpinner />;
+  }
+
+  if (!hasPermissions) {
+    return <NoPermissions />;
   }
 
   // Return render

--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -4,7 +4,7 @@
  * The goal is provide the steps to register and add
  * a new domain service.
  */
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 
 import { Button, Modal, ModalVariant, PageGroup, PageSection, PageSectionVariants, Text, Wizard, WizardStep } from '@patternfly/react-core';
@@ -24,6 +24,7 @@ import PageServiceDetails from './Components/PageServiceDetails/PageServiceDetai
 import PageReview from './Components/PageReview/PageReview';
 import CenteredSpinner from '../../Components/CenteredSpinner/CenteredSpinner';
 import useIdmPermissions from '../../Hooks/useIdmPermissions';
+import NoPermissions from '../../Components/NoPermissions/NoPermissions';
 
 /**
  * Wizard page to register a new domain into the service.
@@ -41,17 +42,11 @@ const WizardPage = () => {
   const { notifySuccess, notifyWarning, notifyError, removeNotification } = useNotification();
   const [isCancelConfirmationModalOpen, SetIsCancelConfirmationModalOpen] = useState<boolean>(false);
   const rbac = useIdmPermissions();
+  const hasPermissions = !rbac.isLoading && rbac.permissions.hasTokenCreate && rbac.permissions.hasDomainsUpdate;
 
   // FIXME Update the URL with the location for docs
   const linkLearnMoreAbout = 'https://access.redhat.com/articles/1586893';
   const linkLearnMoreAboutRemovingDirectoryAndDomainServices = 'https://access.redhat.com/articles/1586893';
-
-  useEffect(() => {
-    if (!rbac.isLoading && (!rbac.permissions.hasTokenCreate || !rbac.permissions.hasDomainsUpdate)) {
-      navigate('/no-permissions', { replace: true });
-      return;
-    }
-  }, [rbac]);
 
   const notifyNotCompleted = () => {
     const notificationID = 'domain-registration-cancelled-notification';
@@ -240,6 +235,10 @@ const WizardPage = () => {
 
   if (rbac.isLoading) {
     return <CenteredSpinner />;
+  }
+
+  if (!hasPermissions) {
+    return <NoPermissions />;
   }
 
   return (


### PR DESCRIPTION
When accessing a page where a user doesn't have neccessary permissions for the page, the user was previously redirected to a "NoPermissions" page. This is changing it in a way that user is not longer redirected but the NoPermission content is used for the current page instead of the current content.

Thus it won't change page URL and allows to refresh the page to get the content if users permissions change.

https://issues.redhat.com/browse/HMS-4253