### PR TITLE
build: `npm run start-beta` target

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lint:prettier": "prettier --check src",
     "patch:hosts": "fec patch-etc-hosts",
     "start": "HOT=true fec dev",
+    "start-beta": "HOT=true fec dev --clouddotEnv=stage --uiEnv=beta",
     "test": "TZ=UTC jest --verbose --no-cache",
     "test-watch": "TZ=UTC jest --watch",
     "postinstall": "ts-patch install && rimraf .cache",


### PR DESCRIPTION
When running `make run` or `npm run start`, developer has to manually specify HCC environment, e.g. `stage`, and UI environment, e.g., `beta`.

This is "annoying" when the values are always the same, which atm are. Thus introducing a `make run start-beta` which defines these two params and thus it starts serving with single command.