### PR TITLE
fix(HMS-4217): sorting of domains

### DIFF
--- a/src/Components/DomainList/DomainList.tsx
+++ b/src/Components/DomainList/DomainList.tsx
@@ -36,12 +36,12 @@ export interface DomainListProps {
  * @returns an array with the indexable fields for comparing.
  */
 const getSortableRowValues = (domain: Domain): string[] => {
-  const { domain_type } = domain;
+  const { domain_type, domain_id } = domain;
   let { title, auto_enrollment_enabled } = domain;
   title = title || '';
   auto_enrollment_enabled = auto_enrollment_enabled || false;
   const text_auto_enrollment_enabled = auto_enrollment_enabled === true ? 'Enabled' : 'Disabled';
-  return [title, domain_type, text_auto_enrollment_enabled];
+  return [title, domain_id || '', domain_type, text_auto_enrollment_enabled];
 };
 
 type fnCompareRows = (a: Domain, b: Domain) => number;


### PR DESCRIPTION
Sorrting of domains in domains list did not work as the function which was returning rows for sorting did not return one column thus the index for "domain autojoin" returned undefined value for all rows.

Returning the same amount of values as columns fixes the issue.

https://issues.redhat.com/browse/HMS-4217