### PR TITLE
build: launch with no prompts from make rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "lint:prettier": "prettier --check src",
     "patch:hosts": "fec patch-etc-hosts",
     "start": "HOT=true fec dev",
-    "start-beta": "HOT=true fec dev --clouddotEnv=stage --uiEnv=beta",
     "test": "TZ=UTC jest --verbose --no-cache",
     "test-watch": "TZ=UTC jest --watch",
     "postinstall": "ts-patch install && rimraf .cache",

--- a/scripts/mk/crc-frontend.mk
+++ b/scripts/mk/crc-frontend.mk
@@ -33,9 +33,15 @@ prettier: $(NODE_BIN)/prettier  ## Make code prettier
 test:  $(NODE_BIN)/jest ## Execute unit tests
 	npm run test
 
+$(eval NPM_RUN_START:=npm run start)
+ifneq (,$(findstring $(CLOUDDOT_ENV),stage prod))
+ifneq (,$(findstring $(UI_ENV),beta stable))
+$(eval NPM_RUN_START:=npm run start -- --clouddotEnv="$(CLOUDDOT_ENV)" --uiEnv="$(UI_ENV)")
+endif
+endif
 .PHONY: run
-run:$(NODE_BIN)/fec  ## Execute frontend
-	npm run start
+run: $(NODE_BIN)/fec  ## Execute frontend
+	$(NPM_RUN_START)
 
 .PHONY: generate-api
 generate-api: $(NODE_BIN)/openapi-generator-cli $(NODE_BIN)/prettier $(PUBLIC_OPENAPI) ## Generate the API client from openapi specification

--- a/scripts/mk/variables.mk
+++ b/scripts/mk/variables.mk
@@ -4,4 +4,7 @@
 
 APP_NAME := idmsvc
 
+# Determine the default run environment
+CLOUDDOT_ENV ?= stage
+UI_ENV ?= beta
 


### PR DESCRIPTION
This change move the options to launch with no prompts to the make rules.

By default use the options commonly used for development but could be customized.

Inspired by: https://github.com/podengo-project/idmsvc-frontend/pull/77