### PR TITLE
fix(HMS-4377): no display links

### DIFF
--- a/src/Routes/DefaultPage/DefaultPage.tsx
+++ b/src/Routes/DefaultPage/DefaultPage.tsx
@@ -1,6 +1,5 @@
 import { useNavigate } from 'react-router-dom';
 import React, { useContext, useEffect, useState } from 'react';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/esm/icons/external-link-alt-icon';
 import { RegistryIcon } from '@patternfly/react-icons/dist/esm/icons/registry-icon';
 
 import {
@@ -37,27 +36,12 @@ import useIdmPermissions from '../../Hooks/useIdmPermissions';
 import NoPermissions from '../../Components/NoPermissions/NoPermissions';
 
 const Header = () => {
-  const linkLearnMoreAbout = 'https://access.redhat.com/articles/1586893';
   const title = 'Directory and Domain Services';
 
   return (
     <PageHeader>
       <PageHeaderTitle title={title} />
-      <p>
-        Register identity and access management systems to enable machines to automatically join a domain.{' '}
-        <Button
-          component="a"
-          target="_blank"
-          variant="link"
-          isInline
-          icon={<ExternalLinkAltIcon />}
-          iconPosition="right"
-          href={linkLearnMoreAbout}
-          ouiaId="LinkDefaultLearnMoreAbout1"
-        >
-          Learn more about the Directory and Domain Services registry.
-        </Button>
-      </p>
+      <p>Register identity and access management systems to enable machines to automatically join a domain.</p>
     </PageHeader>
   );
 };
@@ -84,9 +68,6 @@ const RegisterDomainButton = () => {
 };
 
 const EmptyContent = () => {
-  // FIXME Update this link in the future
-  const linkLearnMoreAbout = 'https://access.redhat.com/articles/1586893';
-
   return (
     <>
       <Section>
@@ -102,20 +83,7 @@ const EmptyContent = () => {
                 <StackItem className="pf-v5-u-pt-md">
                   <RegisterDomainButton />
                 </StackItem>
-                <StackItem className="pf-v5-u-pt-md">
-                  <Button
-                    component="a"
-                    target="_blank"
-                    variant="link"
-                    isInline
-                    icon={<ExternalLinkAltIcon />}
-                    iconPosition="right"
-                    href={linkLearnMoreAbout}
-                    ouiaId="LinkDefaultLearnMoreAbout2"
-                  >
-                    Learn more about registering identity domains{' '}
-                  </Button>
-                </StackItem>
+                <StackItem className="pf-v5-u-pt-md"></StackItem>
                 <StackItem className="pf-v5-u-pt-lg pf-v5-u-color-100">
                   *Only currently available for Red Hat Identity Management (IdM) deployments.
                 </StackItem>

--- a/src/Routes/WizardPage/Components/PagePreparation/PagePreparation.tsx
+++ b/src/Routes/WizardPage/Components/PagePreparation/PagePreparation.tsx
@@ -26,8 +26,6 @@ interface PagePreparationProps {
 const PagePreparation = (props: PagePreparationProps) => {
   // FIXME Update the target link when it is known
   const installServerPackagesLink = 'https://duckduckgo.com/?q=freeipa+prerequisites';
-  // FIXME Update the target link when it is known
-  const prerequisitesLink = 'https://www.google.com?q=rhel-idm+pre-requisites';
 
   // States
   const appContext = useContext(AppContext);
@@ -93,21 +91,6 @@ const PagePreparation = (props: PagePreparationProps) => {
         </FormGroup>
         <FormGroup label="Identity domain prerequisites">
           <ol>
-            <li className="pf-v5-u-pt-sd pf-v5-u-ml-md">
-              Complete the{' '}
-              <Button
-                component="a"
-                target="_blank"
-                variant="link"
-                icon={<ExternalLinkAltIcon />}
-                iconPosition="right"
-                isInline
-                href={prerequisitesLink}
-                ouiaId="ButtonPagePreparationPrerequisites"
-              >
-                prerequisites
-              </Button>
-            </li>
             <li className="pf-v5-u-pt-md pf-v5-u-ml-md">
               <TextContent>
                 Verify whether or not the package is present on your Red Hat IdM server(s) by running the following command in a terminal on your Red

--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -45,7 +45,6 @@ const WizardPage = () => {
   const hasPermissions = !rbac.isLoading && rbac.permissions.hasTokenCreate && rbac.permissions.hasDomainsUpdate;
 
   // FIXME Update the URL with the location for docs
-  const linkLearnMoreAbout = 'https://access.redhat.com/articles/1586893';
   const linkLearnMoreAboutRemovingDirectoryAndDomainServices = 'https://access.redhat.com/articles/1586893';
 
   const notifyNotCompleted = () => {
@@ -246,21 +245,7 @@ const WizardPage = () => {
       <PageGroup>
         <PageHeader>
           <PageHeaderTitle title={title} ouiaId="TextWizardTitle" />
-          <p>
-            Add an identity domain to the registry.{' '}
-            <Button
-              component="a"
-              target="_blank"
-              variant="link"
-              isInline
-              icon={<ExternalLinkAltIcon />}
-              iconPosition="right"
-              href={linkLearnMoreAbout}
-              ouiaId="LinkWizardHeaderLearnAbout"
-            >
-              Learn more about registering identity domains{' '}
-            </Button>
-          </p>
+          <p>Add an identity domain to the registry.</p>
         </PageHeader>
         <PageSection type={'wizard'} variant={PageSectionVariants.light}>
           <Wizard navAriaLabel={`${title} steps`} isVisitRequired={true} onClose={onWizardClose} onSave={onWizardSave}>


### PR DESCRIPTION
This change remove links that will exist
in the future, to avoid confusion for the
end user.

Specifically:

- It removes the 'learning more ...' link at the header of the empty page and wizard.
- It removes the 'pre-requisites' link in the first page of the wizard.