### PR TITLE
chore: stage:stable as default fec env

### DIFF
--- a/config/bonfire.example.yaml
+++ b/config/bonfire.example.yaml
@@ -12,7 +12,7 @@ apps:
       # pushed to the repository.
       - name: backend
         host: github
-        repo: pondengo-project/idmsvc-backend
+        repo: podengo-project/idmsvc-backend
         path: deployments/clowder.yaml
         parameters:
           ENV_NAME: "ephemeral"

--- a/scripts/mk/variables.mk
+++ b/scripts/mk/variables.mk
@@ -6,5 +6,5 @@ APP_NAME := idmsvc
 
 # Determine the default run environment
 CLOUDDOT_ENV ?= stage
-UI_ENV ?= beta
+UI_ENV ?= stable
 


### PR DESCRIPTION
Instead of stage:beta which no longer works.

Also fixing a typo in ephemeral deployment template.