### PR TITLE
chore(HMS-4521): ephemeral logging - debug level and source location

### DIFF
--- a/config/bonfire.example.yaml
+++ b/config/bonfire.example.yaml
@@ -16,7 +16,8 @@ apps:
         path: deployments/clowder.yaml
         parameters:
           ENV_NAME: "ephemeral"
-          # LOGGING_LEVEL: "info"
+          LOGGING_LEVEL: "debug"
+          LOGGING_LOCATION: "true"
           CLIENTS_RBAC_BASE_URL: "http://rbac-service:8000/api/rbac/v1"
           CLIENTS_RBAC_ENABLED: "True"
           # SERVICE_REPLICAS: 3
@@ -26,7 +27,7 @@ apps:
       # environment by using the repository automation.
       - name: frontend
         # host: github
-        # repo: idmsvc/idmsvc-frontend
+        # repo: podengo-project/idmsvc-frontend
         host: local
         repo: ./
         path: deploy/frontend.yaml


### PR DESCRIPTION
Debug level and source code location logging was set for idmsvc-backend so that the template is more usable out of the box. The default was "warn". Thus it is easier to investigate requests done to the API.

Source code location logging is now consistent with idmsvc-backend repo.

Also fixes incorrect GitHub namesapce.