### PR TITLE
fix(HMS-2141): update link and contents

### DIFF
--- a/src/Routes/WizardPage/Components/PagePreparation/PagePreparation.tsx
+++ b/src/Routes/WizardPage/Components/PagePreparation/PagePreparation.tsx
@@ -24,8 +24,8 @@ interface PagePreparationProps {
  * @see {@link WizardPage} to know about the parent component.
  */
 const PagePreparation = (props: PagePreparationProps) => {
-  // FIXME Update the target link when it is known
-  const installServerPackagesLink = 'https://duckduckgo.com/?q=freeipa+prerequisites';
+  const deployAndManaingIPASystemsLink =
+    'https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html-single/deploying_and_managing_rhel_systems_in_hybrid_clouds/index#managing-external-authentication-and-authorization-domains_host-management-services';
 
   // States
   const appContext = useContext(AppContext);
@@ -87,42 +87,32 @@ const PagePreparation = (props: PagePreparationProps) => {
             variant="info"
             isInline
             ouiaId="AlertPagePreparationPrepare"
-          ></Alert>
+          >
+            <Button
+              component="a"
+              target="_blank"
+              variant="link"
+              isInline
+              href={deployAndManaingIPASystemsLink}
+              icon={<ExternalLinkAltIcon />}
+              iconPosition="right"
+              ouiaId="LinkWizardRegistrationLearnMore"
+            >
+              Deploying and managing RHEL systems in hybrid clouds
+            </Button>
+          </Alert>
         </FormGroup>
         <FormGroup label="Identity domain prerequisites">
-          <ol>
-            <li className="pf-v5-u-pt-md pf-v5-u-ml-md">
-              <TextContent>
-                Verify whether or not the package is present on your Red Hat IdM server(s) by running the following command in a terminal on your Red
-                Hat IdM server(s):
-              </TextContent>
-              <ClipboardCopy hoverTip="copy" clickTip="Copied" isReadOnly ouiaId="TextWizardPagePrepareCheckInstall">
-                dnf list installed ipa-hcc-server
-              </ClipboardCopy>
-              <TextContent className="pf-v5-u-pt-md">
-                If the package is not present on your Red Hat IdM server(s), follow these{' '}
-                <Button
-                  component="a"
-                  target="_blank"
-                  variant="link"
-                  icon={<ExternalLinkAltIcon />}
-                  iconPosition="right"
-                  isInline
-                  href={installServerPackagesLink}
-                  ouiaId="LinkPagePreparationInstall"
-                >
-                  steps to install the server packages
-                </Button>
-                <ClipboardCopy hoverTip="copy" clickTip="Copied" isReadOnly ouiaId="TextPagePreparationInstallPackage">
-                  dnf install ipa-hcc-server
-                </ClipboardCopy>
-              </TextContent>
-              <TextContent className="pf-v5-u-pt-md">
-                The package must be installed on at least one Red Hat IdM server. For redundancy, the package should be installed on two or more Red
-                Hat IdM servers.
-              </TextContent>
-            </li>
-          </ol>
+          <TextContent className="pf-v5-u-pt-md">
+            Install the ipa-hcc-server package in your Red Hat IdM server(s), by:
+            <ClipboardCopy hoverTip="copy" clickTip="Copied" isReadOnly ouiaId="TextPagePreparationInstallPackage">
+              dnf install ipa-hcc-server
+            </ClipboardCopy>
+          </TextContent>
+          <TextContent className="pf-v5-u-pt-md">
+            The package must be installed on at least one Red Hat IdM server. For redundancy, the package should be installed on two or more Red Hat
+            IdM servers.
+          </TextContent>
         </FormGroup>
       </Form>
     </>

--- a/src/Routes/WizardPage/Components/PageServiceRegistration/PageServiceRegistration.tsx
+++ b/src/Routes/WizardPage/Components/PageServiceRegistration/PageServiceRegistration.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Alert, Button, ClipboardCopy, Flex, FlexItem, Form, TextContent, Title } from '@patternfly/react-core';
+import { Alert, ClipboardCopy, Flex, FlexItem, Form, TextContent, Title } from '@patternfly/react-core';
 
 import './PageServiceRegistration.scss';
 import VerifyRegistry, { VerifyState } from '../VerifyRegistry/VerifyRegistry';
@@ -29,25 +29,10 @@ interface PageServiceRegistrationProp {
  * @public
  */
 const PageServiceRegistration = (props: PageServiceRegistrationProp) => {
-  // FIXME Update the URL with the location for docs
-  // const installServerPackagesLink = 'https://freeipa.org/page/Quick_Start_Guide';
   const [state, setState] = useState<VerifyState>('initial');
-
-  // FIXME Clean-up when sure it is not needed
-  // const openInNewWindow = (url: string) => {
-  //   window.open(url, '_blank');
-  // };
-
-  // FIXME Clean-up when sure it is not needed
-  // const onInstallServerPackagesClick = () => {
-  //   openInNewWindow(installServerPackagesLink);
-  // };
 
   const ipa_hcc_register_cmd = 'ipa-hcc register ' + props.token;
   const alertTitle = 'Register your identity domain';
-
-  // FIXME Update the URL with the location for docs
-  const linkLearnMoreAbout = 'https://www.google.es/search?q=freeipa+registering+a+domain+service';
 
   const onChangeVerifyRegistry = (newState: VerifyState, domain?: Domain) => {
     setState(newState);
@@ -66,11 +51,6 @@ const PageServiceRegistration = (props: PageServiceRegistrationProp) => {
       <Form onSubmit={(e) => e.preventDefault()}>
         <Alert title={alertTitle} variant="warning" isInline className="pf-v5-u-mt-lg" ouiaId="AlertWizardRegistrationNote">
           Completing this step registers your identity domain, and cannot be undone from the wizard.{' '}
-          <div className="pf-v5-u-mt-md">
-            <Button component="a" target="_blank" variant="link" isInline href={linkLearnMoreAbout} ouiaId="LinkWizardRegistrationLearnMore">
-              Learn more about registering identity domains
-            </Button>
-          </div>
         </Alert>
         <ol>
           <li className="pf-v5-u-ml-md">

--- a/src/Routes/WizardPage/Components/VerifyRegistry/VerifyRegistry.tsx
+++ b/src/Routes/WizardPage/Components/VerifyRegistry/VerifyRegistry.tsx
@@ -5,7 +5,6 @@ import { Button, Icon, Stack, StackItem, TextContent } from '@patternfly/react-c
 import { CheckCircleIcon } from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import { PendingIcon } from '@patternfly/react-icons/dist/js/icons/pending-icon';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 import './VerifyRegistry.scss';
 import { Domain, ResourcesApiFactory } from '../../../../Api/idmsvc';
@@ -96,7 +95,6 @@ interface VerifyRegistryFooterProps {
 }
 
 const VerifyRegistryFooter = (props: VerifyRegistryFooterProps) => {
-  const linkTroubleshootRegistration = 'https://www.google.com/search?q=freeipa+troubleshooting';
   return (
     <>
       {props.state == 'initial' && (
@@ -114,21 +112,7 @@ const VerifyRegistryFooter = (props: VerifyRegistryFooterProps) => {
           </Button>
         </>
       )}
-      {props.state == 'not-found' && (
-        <>
-          <Button
-            isInline
-            variant="link"
-            target="_blank"
-            href={linkTroubleshootRegistration}
-            icon={<ExternalLinkAltIcon />}
-            iconPosition="right"
-            ouiaId="ButtonVerifyTroubleshoot"
-          >
-            Troubleshoot registration
-          </Button>
-        </>
-      )}
+      {props.state == 'not-found' && <></>}
       {props.state == 'completed' && (
         <>
           <Button variant="secondary" onClick={props.onTest} ouiaId="ButtonVerifyCompleted">

--- a/src/Routes/WizardPage/WizardPage.tsx
+++ b/src/Routes/WizardPage/WizardPage.tsx
@@ -5,7 +5,6 @@
  * a new domain service.
  */
 import React, { useContext, useState } from 'react';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
 
 import { Button, Modal, ModalVariant, PageGroup, PageSection, PageSectionVariants, Text, Wizard, WizardStep } from '@patternfly/react-core';
 
@@ -43,9 +42,6 @@ const WizardPage = () => {
   const [isCancelConfirmationModalOpen, SetIsCancelConfirmationModalOpen] = useState<boolean>(false);
   const rbac = useIdmPermissions();
   const hasPermissions = !rbac.isLoading && rbac.permissions.hasTokenCreate && rbac.permissions.hasDomainsUpdate;
-
-  // FIXME Update the URL with the location for docs
-  const linkLearnMoreAboutRemovingDirectoryAndDomainServices = 'https://access.redhat.com/articles/1586893';
 
   const notifyNotCompleted = () => {
     const notificationID = 'domain-registration-cancelled-notification';
@@ -358,18 +354,6 @@ const WizardPage = () => {
               Proceeding with the cancellation, your data will not be saved in the Red Hat Hybrid Cloud Console. However, this action does not affect
               the identity server side if any action is done there.
             </Text>
-            <Button
-              component="a"
-              target="_blank"
-              variant="link"
-              icon={<ExternalLinkAltIcon />}
-              iconPosition="right"
-              isInline
-              href={linkLearnMoreAboutRemovingDirectoryAndDomainServices}
-              ouiaId="ButtonPagePreparationPrerequisites"
-            >
-              Learn more about removing Directory and Domain Services Packages from your Red hat IdM server
-            </Button>
           </Modal>
         </PageSection>
       </PageGroup>


### PR DESCRIPTION
- Wizard Page 1 - Preparation: Remove paragraph about the pre-requisites and package verification, and leave only the 2nd and 3rd paragraph indicating the package to be installed. Remove the link about steps to install the server packages. Remove the link about pre-requisites. The link in the alert point out to documentation about "Deploying and managing RHEL systems in hybrid clouds".

- Wizard page 2 - Registration: Remove the link in the warning alert.

- The verify component remove the link to troubleshooting, when is in error state.

- The cancel wizard registration modal remove the link intended to provide information about deleting an ipa server, as the process is more related with the registration with the hcc.

Credits on: @ragevou

TODO

- [ ] Feedback and comments to update the PR.

https://issues.redhat.com/browse/HMS-2141