### PR TITLE
fix(HMS-4621): remove beta/preview URL prefixespreview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # idm-domains-frontend
 
-## Initial etc/hosts setup
+## Initial /etc/hosts setup
 
 In order to access the https://[env].foo.redhat.com in your browser, you have to add entries to your `/etc/hosts` file. This is a **one-time** setup that has to be done only once (unless you modify hosts) on each machine.
 
@@ -11,8 +11,6 @@ Add the below to your `/etc/hosts` file:
 ```
 127.0.0.1 prod.foo.redhat.com
 127.0.0.1 stage.foo.redhat.com
-127.0.0.1 qa.foo.redhat.com
-127.0.0.1 ci.foo.redhat.com
 ```
 
 ## Install react developer tools
@@ -22,7 +20,7 @@ favourite browser.
 
 - [React Developer Tools](https://react.dev/learn/react-developer-tools).
 
-## Setup and run chrome-service-backend
+## Setup and run chrome-service-backend (optional)
 
 > Useful when trying your service config changes
 > before commit to chrome-service-backend repository.
@@ -59,11 +57,7 @@ Now you can deploy into dev cluster by `make ephemeral-build-deploy`.
 
 1. `make run` to start the server.
 
-2. Open the [idmsvc beta app][idmsvc_beta_app] in your browser.
-
-3. Currently, `App.tsx` will throw a type error until your app is registered and a `navId` has been set.
-
-Update `config/dev.webpack.config.js` according to your application URL. [Read more][frontend_use_proxy].
+2. Open the [idmsvc app][idmsvc_app] in your browser.
 
 See: [Contributing](./docs/CONTRIBUTING.md).
 
@@ -79,8 +73,8 @@ Update git submodule and regenerate API with `make update-api`.
 Generate `src/Api` from the openapi specification by running `make generate-api`.
 
 * [Development Docs](docs/INDEX.md).
-* [Pattern Fly 4 - Components][patternfly_4].
+* [PatternFly - Components][patternfly].
 
-[idmsvc_beta_app]: https://stage.foo.redhat.com:1337/beta/settings/idmsvc
-[patternfly_4]: https://v4-archive.patternfly.org/v4/components/about-modal
+[idmsvc_app]: https://stage.foo.redhat.com:1337/settings/idmsvc
+[patternfly]: https://www.patternfly.org/components/all-components
 [frontend_use_proxy]: https://github.com/RedHatInsights/frontend-components/tree/master/packages/config#useproxy

--- a/build/package/Caddyfile
+++ b/build/package/Caddyfile
@@ -38,24 +38,8 @@
         }
     }
 
-    # Handle preview app route
-    @preview_match {
-        path /preview/apps/idmsvc*
-    }
-    handle @preview_match {
-        uri strip_prefix /preview/apps/idmsvc*
-        file_server * {
-            root /opt/app-root/src/dist/preview
-            browse
-        }
-    }
-
     handle /beta/ {
         redir /beta/apps/chrome/index.html permanent
-    }
-
-    handle /preview/ {
-        redir /preview/apps/chrome/index.html permanent
     }
 
     handle / {

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -40,9 +40,6 @@ COPY ./package.json /opt/app-root/src/
 RUN sed -i -e 's/\/beta\/apps/\/apps/g' /opt/app-root/src/dist/stable/fed-mods.json
 
 ENV APP_NAME="idmsvc"
-ENV ROUTE_PATH="/apps/${APP_NAME}"
-ENV BETA_ROUTE_PATH="/beta/apps/${APP_NAME}"
-ENV PREVIEW_ROUTE_PATH="/preview/apps/${APP_NAME}"
 
 CMD ["caddy", "run", "--config", "/opt/app-root/src/Caddyfile"]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@openapitools/openapi-generator-cli": "^2.13.5",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.4",
-        "@redhat-cloud-services/frontend-components-config": "^6.0.13",
+        "@redhat-cloud-services/frontend-components-config": "^6.2.8",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.10",
         "@testing-library/jest-dom": "^6.4.5",
         "@testing-library/react": "^15.0.7",
@@ -2045,6 +2045,21 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -3593,9 +3608,9 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk-webpack/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3804,30 +3819,30 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.0.13.tgz",
-      "integrity": "sha512-fABmXUguiFAZp3DCun2cE1wpDaK1ZTYGVCs9f7fg0FB0rENaPK3B7twviLON3Y4OdOX9dHg/e7LYzNrbvH04MQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.2.8.tgz",
+      "integrity": "sha512-1B8DFu8kSfcxuc7AULKzLulnaN3HfQwQcArDBLGz/uN8hRmBxe02ZER23HptNieXlzKQ3zt1d6vTMey0AbfSEw==",
       "dev": true,
       "dependencies": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.5",
-        "@redhat-cloud-services/tsc-transform-imports": "^1.0.8",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^3.2.2",
+        "@redhat-cloud-services/tsc-transform-imports": "^1.0.12",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
-        "axios": "^0.28.1",
+        "axios": "^0.28.1 || ^1.7.0",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.2",
         "clean-webpack-plugin": "^3.0.0",
         "concurrently": "^7.4.0",
         "css-loader": "^5.2.7",
-        "express": "^4.18.1",
+        "express": "^4.19.2",
         "fork-ts-checker-webpack-plugin": "^7.2.13",
         "git-revision-webpack-plugin": "^3.0.6",
         "glob": "^7.2.3",
         "html-replace-webpack-plugin": "^2.6.0",
         "html-webpack-plugin": "^5.5.0",
-        "http-server": "^13.1.0",
+        "http-server": "^14.0.0",
         "https-proxy-agent": "^5.0.1",
         "inquirer": "^8.2.4",
         "js-yaml": "^4.1.0",
@@ -3842,9 +3857,11 @@
         "source-map-loader": "^3.0.1",
         "stream-browserify": "^3.0.0",
         "swc-loader": "^0.2.3",
+        "tree-kill": "^1.2.2",
         "ts-loader": "^9.4.4",
         "url": "^0.11.0",
         "util": "^0.12.4",
+        "wait-on": "^7.2.0",
         "webpack": "^5.88.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "4.15.1",
@@ -3855,9 +3872,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-3.0.5.tgz",
-      "integrity": "sha512-4ifJPmU/Mb7VjUwCy0b4/E/QlDuEOvcCqGV7HGiRQPxy7sYcalhS2NPvKMPuEuEy6yOLigryurXmbA+jlK2LLA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-3.2.2.tgz",
+      "integrity": "sha512-Zfc1lEvvhZcRWklSZCa17UlytCjCEh/cn3umEEpx7LLcBYfRRIQjNc7L/iKxGpA1mJUVOaNk1G7i1oO39D7FCQ==",
       "dev": true,
       "dependencies": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
@@ -3951,17 +3968,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/axios": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
-      "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/chalk": {
@@ -4095,9 +4101,9 @@
       }
     },
     "node_modules/@redhat-cloud-services/tsc-transform-imports": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.0.10.tgz",
-      "integrity": "sha512-IzZsgGrpE3XaGk7UBVryjUftL/Pd2FKsjf92MhzD6z7FnvtKiQsx7CnLBi6wcaAAT1VWi5HuWIIziS6wVmLGbQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.0.16.tgz",
+      "integrity": "sha512-2GbDEV3t0E/s9v1TresBtehlXX0pLMOmlI9j1ThQUCTwQ8c5dvITu1neJIDexiZa40GaIKlPfmqkt0jxq93GYQ==",
       "dev": true,
       "dependencies": {
         "glob": "10.3.3"
@@ -4287,6 +4293,27 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -6363,13 +6390,22 @@
       ]
     },
     "node_modules/basic-auth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
-      "integrity": "sha512-CtGuTyWf3ig+sgRyC7uP6DM3N+5ur/p8L+FPfsd+BbIfIs74TFfCajZTHnCw6K5dqM0bZEbRIqRy1fAdiUJhTA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
       "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/batch": {
       "version": "0.6.1",
@@ -6638,13 +6674,19 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7777,6 +7819,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -8254,6 +8313,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.2.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-module-lexer": {
@@ -9505,10 +9585,13 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -9556,15 +9639,19 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
       "dependencies": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9839,12 +9926,12 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9887,6 +9974,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -10172,29 +10271,30 @@
       }
     },
     "node_modules/http-server": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-13.1.0.tgz",
-      "integrity": "sha512-MLqBMXeY/YN0FYMz4ifeOQCcg8pKj8YdmzX1pr/Vb2VrNnbxHN1s4K9BuZRVSyK/j3DQ8UVrrABb8m6EmFjWog==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
       "dev": true,
       "dependencies": {
-        "basic-auth": "^1.0.3",
+        "basic-auth": "^2.0.1",
         "chalk": "^4.1.2",
         "corser": "^2.0.1",
-        "he": "^1.1.0",
-        "http-proxy": "^1.18.0",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
         "mime": "^1.6.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "opener": "^1.5.1",
-        "portfinder": "^1.0.25",
+        "portfinder": "^1.0.28",
         "secure-compare": "3.0.1",
         "union": "~0.5.0",
-        "url-join": "^2.0.5"
+        "url-join": "^4.0.1"
       },
       "bin": {
         "http-server": "bin/http-server"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/http-server/node_modules/ansi-styles": {
@@ -13272,6 +13372,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "dependencies": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14692,10 +14805,13 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -15770,12 +15886,12 @@
       ]
     },
     "node_modules/qs": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -16937,6 +17053,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -16991,14 +17124,18 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18539,9 +18676,9 @@
       }
     },
     "node_modules/url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha512-c2H1fIgpUdwFRIru9HFno5DT73Ok8hg5oOb5AT3ayIgvCRfxgs2jyt5Slw8kEB7j3QUr6yJmMPDT/odjk7jXow==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "node_modules/url-parse": {
@@ -18659,6 +18796,25 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/walker": {
@@ -20875,6 +21031,21 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
       "dev": true
     },
+    "@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
+    },
+    "@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -22028,9 +22199,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.6.2",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+          "version": "7.6.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
           "dev": true
         }
       }
@@ -22156,30 +22327,30 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.0.13.tgz",
-      "integrity": "sha512-fABmXUguiFAZp3DCun2cE1wpDaK1ZTYGVCs9f7fg0FB0rENaPK3B7twviLON3Y4OdOX9dHg/e7LYzNrbvH04MQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-6.2.8.tgz",
+      "integrity": "sha512-1B8DFu8kSfcxuc7AULKzLulnaN3HfQwQcArDBLGz/uN8hRmBxe02ZER23HptNieXlzKQ3zt1d6vTMey0AbfSEw==",
       "dev": true,
       "requires": {
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
-        "@redhat-cloud-services/frontend-components-config-utilities": "^3.0.5",
-        "@redhat-cloud-services/tsc-transform-imports": "^1.0.8",
+        "@redhat-cloud-services/frontend-components-config-utilities": "^3.2.2",
+        "@redhat-cloud-services/tsc-transform-imports": "^1.0.12",
         "@swc/core": "^1.3.76",
         "assert": "^2.0.0",
-        "axios": "^0.28.1",
+        "axios": "^0.28.1 || ^1.7.0",
         "browserify-zlib": "^0.2.0",
         "buffer": "^6.0.3",
         "chalk": "^4.1.2",
         "clean-webpack-plugin": "^3.0.0",
         "concurrently": "^7.4.0",
         "css-loader": "^5.2.7",
-        "express": "^4.18.1",
+        "express": "^4.19.2",
         "fork-ts-checker-webpack-plugin": "^7.2.13",
         "git-revision-webpack-plugin": "^3.0.6",
         "glob": "^7.2.3",
         "html-replace-webpack-plugin": "^2.6.0",
         "html-webpack-plugin": "^5.5.0",
-        "http-server": "^13.1.0",
+        "http-server": "^14.0.0",
         "https-proxy-agent": "^5.0.1",
         "inquirer": "^8.2.4",
         "js-yaml": "^4.1.0",
@@ -22194,9 +22365,11 @@
         "source-map-loader": "^3.0.1",
         "stream-browserify": "^3.0.0",
         "swc-loader": "^0.2.3",
+        "tree-kill": "^1.2.2",
         "ts-loader": "^9.4.4",
         "url": "^0.11.0",
         "util": "^0.12.4",
+        "wait-on": "^7.2.0",
         "webpack": "^5.88.0",
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "4.15.1",
@@ -22210,17 +22383,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "axios": {
-          "version": "0.28.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.28.1.tgz",
-          "integrity": "sha512-iUcGA5a7p0mVb4Gm/sy+FSECNkPFT4y7wt6OM/CDpO/OnNCvSs3PoMG8ibrC9jRoGYU0gUK5pXVC4NPXq6lHRQ==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
           }
         },
         "chalk": {
@@ -22266,9 +22428,9 @@
       }
     },
     "@redhat-cloud-services/frontend-components-config-utilities": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-3.0.5.tgz",
-      "integrity": "sha512-4ifJPmU/Mb7VjUwCy0b4/E/QlDuEOvcCqGV7HGiRQPxy7sYcalhS2NPvKMPuEuEy6yOLigryurXmbA+jlK2LLA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-3.2.2.tgz",
+      "integrity": "sha512-Zfc1lEvvhZcRWklSZCa17UlytCjCEh/cn3umEEpx7LLcBYfRRIQjNc7L/iKxGpA1mJUVOaNk1G7i1oO39D7FCQ==",
       "dev": true,
       "requires": {
         "@openshift/dynamic-plugin-sdk-webpack": "^4.0.1",
@@ -22388,9 +22550,9 @@
       }
     },
     "@redhat-cloud-services/tsc-transform-imports": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.0.10.tgz",
-      "integrity": "sha512-IzZsgGrpE3XaGk7UBVryjUftL/Pd2FKsjf92MhzD6z7FnvtKiQsx7CnLBi6wcaAAT1VWi5HuWIIziS6wVmLGbQ==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/tsc-transform-imports/-/tsc-transform-imports-1.0.16.tgz",
+      "integrity": "sha512-2GbDEV3t0E/s9v1TresBtehlXX0pLMOmlI9j1ThQUCTwQ8c5dvITu1neJIDexiZa40GaIKlPfmqkt0jxq93GYQ==",
       "dev": true,
       "requires": {
         "glob": "10.3.3"
@@ -22549,6 +22711,27 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
+    },
+    "@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
+    },
+    "@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "@sinclair/typebox": {
       "version": "0.27.8",
@@ -24125,10 +24308,21 @@
       "dev": true
     },
     "basic-auth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
-      "integrity": "sha512-CtGuTyWf3ig+sgRyC7uP6DM3N+5ur/p8L+FPfsd+BbIfIs74TFfCajZTHnCw6K5dqM0bZEbRIqRy1fAdiUJhTA==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
     },
     "batch": {
       "version": "0.6.1",
@@ -24330,13 +24524,16 @@
       "dev": true
     },
     "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
+      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.1"
       }
     },
     "callsites": {
@@ -25172,6 +25369,17 @@
         "clone": "^1.0.2"
       }
     },
+    "define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "requires": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      }
+    },
     "define-lazy-prop": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
@@ -25544,6 +25752,21 @@
         "unbox-primitive": "^1.0.2",
         "which-typed-array": "^1.1.9"
       }
+    },
+    "es-define-property": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
+      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.2.4"
+      }
+    },
+    "es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true
     },
     "es-module-lexer": {
       "version": "1.2.1",
@@ -26475,9 +26698,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
     "function.prototype.name": {
@@ -26511,15 +26734,16 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-      "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
+      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3"
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
       }
     },
     "get-package-type": {
@@ -26721,12 +26945,12 @@
       "dev": true
     },
     "has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "requires": {
-        "get-intrinsic": "^1.1.1"
+        "es-define-property": "^1.0.0"
       }
     },
     "has-proto": {
@@ -26748,6 +26972,15 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.2"
       }
     },
     "he": {
@@ -26977,23 +27210,24 @@
       }
     },
     "http-server": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-13.1.0.tgz",
-      "integrity": "sha512-MLqBMXeY/YN0FYMz4ifeOQCcg8pKj8YdmzX1pr/Vb2VrNnbxHN1s4K9BuZRVSyK/j3DQ8UVrrABb8m6EmFjWog==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
       "dev": true,
       "requires": {
-        "basic-auth": "^1.0.3",
+        "basic-auth": "^2.0.1",
         "chalk": "^4.1.2",
         "corser": "^2.0.1",
-        "he": "^1.1.0",
-        "http-proxy": "^1.18.0",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
         "mime": "^1.6.0",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "opener": "^1.5.1",
-        "portfinder": "^1.0.25",
+        "portfinder": "^1.0.28",
         "secure-compare": "3.0.1",
         "union": "~0.5.0",
-        "url-join": "^2.0.5"
+        "url-join": "^4.0.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -29234,6 +29468,19 @@
         }
       }
     },
+    "joi": {
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "dev": true,
+      "requires": {
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -30340,9 +30587,9 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
-      "version": "1.12.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
+      "integrity": "sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==",
       "dev": true
     },
     "object-is": {
@@ -31104,12 +31351,12 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
-      "integrity": "sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "requires": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       }
     },
     "querystring": {
@@ -31949,6 +32196,20 @@
         "send": "0.18.0"
       }
     },
+    "set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "requires": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      }
+    },
     "setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -31991,14 +32252,15 @@
       "dev": true
     },
     "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
+      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
       "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+        "call-bind": "^1.0.7",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.4",
+        "object-inspect": "^1.13.1"
       }
     },
     "signal-exit": {
@@ -33118,9 +33380,9 @@
       }
     },
     "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha512-c2H1fIgpUdwFRIru9HFno5DT73Ok8hg5oOb5AT3ayIgvCRfxgs2jyt5Slw8kEB7j3QUr6yJmMPDT/odjk7jXow==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
     },
     "url-parse": {
@@ -33217,6 +33479,19 @@
       "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
+      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
+      "dev": true,
+      "requires": {
+        "axios": "^1.6.1",
+        "joi": "^17.11.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.8",
+        "rxjs": "^7.8.1"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@openapitools/openapi-generator-cli": "^2.13.5",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^2.0.4",
-    "@redhat-cloud-services/frontend-components-config": "^6.0.13",
+    "@redhat-cloud-services/frontend-components-config": "^6.2.8",
     "@redhat-cloud-services/tsc-transform-imports": "^1.0.10",
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.7",

--- a/scripts/mk/crc-frontend.mk
+++ b/scripts/mk/crc-frontend.mk
@@ -35,7 +35,7 @@ test:  $(NODE_BIN)/jest ## Execute unit tests
 
 $(eval NPM_RUN_START:=npm run start)
 ifneq (,$(findstring $(CLOUDDOT_ENV),stage prod))
-ifneq (,$(findstring $(UI_ENV),beta stable))
+ifneq (,$(findstring $(UI_ENV),stable))
 $(eval NPM_RUN_START:=npm run start -- --clouddotEnv="$(CLOUDDOT_ENV)" --uiEnv="$(UI_ENV)")
 endif
 endif

--- a/src/Components/NoPermissions/NoPermissions.test.tsx
+++ b/src/Components/NoPermissions/NoPermissions.test.tsx
@@ -3,12 +3,6 @@ import { render } from '@testing-library/react';
 import NoPermissions from './NoPermissions';
 import '@testing-library/jest-dom';
 
-jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
-  return () => ({
-    isBeta: () => true,
-  });
-});
-
 test('expect NoPermissions to render', () => {
   const { container } = render(<NoPermissions />);
   expect(container).toHaveTextContent('Access permissions needed');

--- a/src/Components/NoPermissions/NoPermissions.tsx
+++ b/src/Components/NoPermissions/NoPermissions.tsx
@@ -2,15 +2,12 @@ import React from 'react';
 
 import { NotAuthorized } from '@redhat-cloud-services/frontend-components/NotAuthorized';
 import { Button, PageSection } from '@patternfly/react-core';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 /**
  * A Component to show when user doesn't have RBAC permissions for the page.
  */
 const NoPermissions = () => {
-  const { isBeta } = useChrome();
-  const prefix = isBeta() ? '/beta' : '/preview';
-  const linkMyUserAccess = prefix + '/iam/my-user-access';
+  const linkMyUserAccess = '/iam/my-user-access';
 
   return (
     <PageSection className="noPermissions">


### PR DESCRIPTION
**fix(HMS-4621): remove beta/preview URL prefixes**

This PR aims to address ADR-044 - removal of /preview URL.

Not all references to /beta or /preview were removed as e.g.
emhemeral environment is still using it.

**chore(HMS-4621): update frontend-components-config to ^6.2.8**

As the newer version addresses removal of /preview URL prefixes.