### PR TITLE
fix(HMS-5181): uncomment rpms-signature-scan

### DIFF
--- a/.tekton/idmsvc-frontend-push.yaml
+++ b/.tekton/idmsvc-frontend-push.yaml
@@ -592,28 +592,28 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
-    # - name: rpms-signature-scan
-    #   params:
-    #   - name: image-url
-    #     value: $(tasks.build-image-index.results.IMAGE_URL)
-    #   - name: image-digest
-    #     value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    #   runAfter:
-    #   - build-image-index
-    #   taskRef:
-    #     params:
-    #     - name: name
-    #       value: rpms-signature-scan
-    #     - name: bundle
-    #       value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
-    #     - name: kind
-    #       value: task
-    #     resolver: bundles
-    #   when:
-    #   - input: $(params.skip-checks)
-    #     operator: in
-    #     values:
-    #     - "false"
+    - name: rpms-signature-scan
+      params:
+      - name: image-url
+        value: $(tasks.build-image-index.results.IMAGE_URL)
+      - name: image-digest
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      runAfter:
+      - build-image-index
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:8f3b23bf1b0ef55cc79d28604d2397a0101ac9c0c42ae26e26532eb2778c801b
+        - name: kind
+          value: task
+        resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
The EC require rpms-signature-scan; this change uncomment the task, and update it aligned with the current definition that we can find in the idmsvc-backend component.

https://issues.redhat.com/browse/HMS-5181